### PR TITLE
feat: scripts/bin/setup の user-facing 文言を日本語化

### DIFF
--- a/bin/dev-setup
+++ b/bin/dev-setup
@@ -18,13 +18,13 @@ if [ ! -f "$REPO_ROOT/.env" ]; then
   MAIN_WORKTREE="$(git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null | head -1 | sed 's/^worktree //')"
   if [ -n "$MAIN_WORKTREE" ] && [ "$MAIN_WORKTREE" != "$REPO_ROOT" ] && [ -f "$MAIN_WORKTREE/.env" ]; then
     cp "$MAIN_WORKTREE/.env" "$REPO_ROOT/.env"
-    echo "Copied .env from main worktree ($MAIN_WORKTREE)"
+    echo "main worktree ($MAIN_WORKTREE) から .env をコピーしました"
   fi
 fi
 
 # 2. Install dependencies
 if [ ! -d "$REPO_ROOT/node_modules" ]; then
-  echo "Installing dependencies..."
+  echo "依存関係をインストールしています..."
   (cd "$REPO_ROOT" && bun install)
 fi
 
@@ -35,11 +35,11 @@ mkdir -p "$REPO_ROOT/.claude/skills"
 # This makes setup think it's inside a real .claude/skills/ directory
 GSTACK_LINK="$REPO_ROOT/.claude/skills/gstack"
 if [ -L "$GSTACK_LINK" ]; then
-  echo "Updating existing symlink..."
+  echo "既存のシンボリックリンクを更新しています..."
   rm "$GSTACK_LINK"
 elif [ -d "$GSTACK_LINK" ]; then
-  echo "Error: .claude/skills/gstack is a real directory, not a symlink." >&2
-  echo "Remove it manually if you want to use dev mode." >&2
+  echo "エラー: .claude/skills/gstack はシンボリックリンクではなく実ディレクトリです。" >&2
+  echo "dev mode を使う場合は手動で削除してください。" >&2
   exit 1
 fi
 ln -s "$REPO_ROOT" "$GSTACK_LINK"
@@ -48,7 +48,7 @@ ln -s "$REPO_ROOT" "$GSTACK_LINK"
 "$GSTACK_LINK/setup"
 
 echo ""
-echo "Dev mode active. Skills resolve from this working tree."
-echo "Edit any SKILL.md and test immediately — no copy/deploy needed."
+echo "Dev mode を有効化しました。skills はこの working tree を参照します。"
+echo "SKILL.md を編集してすぐにテストできます（コピー/デプロイ不要）。"
 echo ""
-echo "To tear down: bin/dev-teardown"
+echo "解除コマンド: bin/dev-teardown"

--- a/bin/dev-teardown
+++ b/bin/dev-teardown
@@ -6,7 +6,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SKILLS_DIR="$REPO_ROOT/.claude/skills"
 
 if [ ! -d "$SKILLS_DIR" ]; then
-  echo "Nothing to tear down — .claude/skills/ doesn't exist."
+  echo "解除対象はありません — .claude/skills/ が存在しません。"
   exit 0
 fi
 
@@ -32,8 +32,8 @@ rmdir "$SKILLS_DIR" 2>/dev/null || true
 rmdir "$REPO_ROOT/.claude" 2>/dev/null || true
 
 if [ ${#removed[@]} -gt 0 ]; then
-  echo "Removed: ${removed[*]}"
+  echo "削除しました: ${removed[*]}"
 else
-  echo "No symlinks found."
+  echo "シンボリックリンクは見つかりませんでした。"
 fi
-echo "Dev mode deactivated. Global gstack (~/.claude/skills/gstack) is now active."
+echo "Dev mode を無効化しました。Global gstack (~/.claude/skills/gstack) が有効です。"

--- a/bin/gstack-config
+++ b/bin/gstack-config
@@ -15,12 +15,12 @@ CONFIG_FILE="$STATE_DIR/config.yaml"
 
 case "${1:-}" in
   get)
-    KEY="${2:?Usage: gstack-config get <key>}"
+    KEY="${2:?使い方: gstack-config get <key>}"
     grep -E "^${KEY}:" "$CONFIG_FILE" 2>/dev/null | tail -1 | awk '{print $2}' | tr -d '[:space:]' || true
     ;;
   set)
-    KEY="${2:?Usage: gstack-config set <key> <value>}"
-    VALUE="${3:?Usage: gstack-config set <key> <value>}"
+    KEY="${2:?使い方: gstack-config set <key> <value>}"
+    VALUE="${3:?使い方: gstack-config set <key> <value>}"
     mkdir -p "$STATE_DIR"
     if grep -qE "^${KEY}:" "$CONFIG_FILE" 2>/dev/null; then
       sed -i '' "s/^${KEY}:.*/${KEY}: ${VALUE}/" "$CONFIG_FILE"
@@ -32,7 +32,7 @@ case "${1:-}" in
     cat "$CONFIG_FILE" 2>/dev/null || true
     ;;
   *)
-    echo "Usage: gstack-config {get|set|list} [key] [value]"
+    echo "使い方: gstack-config {get|set|list} [key] [value]"
     exit 1
     ;;
 esac

--- a/browse/bin/find-browse
+++ b/browse/bin/find-browse
@@ -12,6 +12,6 @@ if [ -n "$ROOT" ] && test -x "$ROOT/.claude/skills/gstack/browse/dist/browse"; t
 elif test -x "$HOME/.claude/skills/gstack/browse/dist/browse"; then
   echo "$HOME/.claude/skills/gstack/browse/dist/browse"
 else
-  echo "ERROR: browse binary not found. Run: cd <skill-dir> && ./setup" >&2
+  echo "ERROR: browse バイナリが見つかりません。実行: cd <skill-dir> && ./setup" >&2
   exit 1
 fi

--- a/scripts/dev-skill.ts
+++ b/scripts/dev-skill.ts
@@ -23,7 +23,7 @@ function regenerateAndValidate() {
   try {
     execSync('bun run scripts/gen-skill-docs.ts', { cwd: ROOT, stdio: 'pipe' });
   } catch (err: any) {
-    console.log(`  [gen]   ERROR: ${err.stderr?.toString().trim() || err.message}`);
+    console.log(`  [gen]   エラー: ${err.stderr?.toString().trim() || err.message}`);
     return;
   }
 
@@ -38,28 +38,28 @@ function regenerateAndValidate() {
     const totalSnapErrors = result.snapshotFlagErrors.length;
 
     if (totalInvalid > 0 || totalSnapErrors > 0) {
-      console.log(`  [check] \u274c ${output} (${totalValid} valid)`);
+      console.log(`  [check] \u274c ${output}（有効: ${totalValid}）`);
       for (const inv of result.invalid) {
-        console.log(`          Unknown command: '${inv.command}' at line ${inv.line}`);
+        console.log(`          不明なコマンド: '${inv.command}'（行 ${inv.line}）`);
       }
       for (const se of result.snapshotFlagErrors) {
-        console.log(`          ${se.error} at line ${se.command.line}`);
+        console.log(`          ${se.error}（行 ${se.command.line}）`);
       }
     } else {
-      console.log(`  [check] \u2705 ${output} — ${totalValid} commands, all valid`);
+      console.log(`  [check] \u2705 ${output} — ${totalValid} コマンド、すべて有効`);
     }
   }
 }
 
 // Initial run
-console.log('  [watch] Watching *.md.tmpl files...');
+console.log('  [watch] *.md.tmpl を監視中...');
 regenerateAndValidate();
 
 // Watch for changes
 for (const { tmpl } of TEMPLATES) {
   if (!fs.existsSync(tmpl)) continue;
   fs.watch(tmpl, () => {
-    console.log(`\n  [watch] ${path.relative(ROOT, tmpl)} changed`);
+    console.log(`\n  [watch] ${path.relative(ROOT, tmpl)} が変更されました`);
     regenerateAndValidate();
   });
 }
@@ -73,10 +73,10 @@ const SOURCE_FILES = [
 for (const src of SOURCE_FILES) {
   if (!fs.existsSync(src)) continue;
   fs.watch(src, () => {
-    console.log(`\n  [watch] ${path.relative(ROOT, src)} changed`);
+    console.log(`\n  [watch] ${path.relative(ROOT, src)} が変更されました`);
     regenerateAndValidate();
   });
 }
 
 // Keep alive
-console.log('  [watch] Press Ctrl+C to stop\n');
+console.log('  [watch] 停止するには Ctrl+C を押してください\n');

--- a/scripts/eval-compare.ts
+++ b/scripts/eval-compare.ts
@@ -24,7 +24,7 @@ function loadResult(filepath: string): EvalResult {
   // Resolve relative to EVAL_DIR if not absolute
   const resolved = path.isAbsolute(filepath) ? filepath : path.join(EVAL_DIR, filepath);
   if (!fs.existsSync(resolved)) {
-    console.error(`File not found: ${resolved}`);
+    console.error(`ファイルが見つかりません: ${resolved}`);
     process.exit(1);
   }
   return JSON.parse(fs.readFileSync(resolved, 'utf-8'));
@@ -46,7 +46,7 @@ if (args.length === 2) {
   const afterResult = loadResult(resolved);
   const prev = findPreviousRun(EVAL_DIR, afterResult.tier, afterResult.branch, resolved);
   if (!prev) {
-    console.log('No previous run found to compare against.');
+    console.log('比較対象となる直前の実行が見つかりません。');
     process.exit(0);
   }
   beforeFile = prev;
@@ -59,12 +59,12 @@ if (args.length === 2) {
       .sort()
       .reverse();
   } catch {
-    console.log('No eval runs yet. Run: EVALS=1 bun run test:evals');
+    console.log('Eval 実行履歴がありません。実行: EVALS=1 bun run test:evals');
     process.exit(0);
   }
 
   if (files.length < 2) {
-    console.log('Need at least 2 eval runs to compare. Run evals again.');
+    console.log('比較には最低 2 件の eval 実行が必要です。もう一度実行してください。');
     process.exit(0);
   }
 
@@ -73,7 +73,7 @@ if (args.length === 2) {
   const afterResult = loadResult(afterFile);
   const prev = findPreviousRun(EVAL_DIR, afterResult.tier, afterResult.branch, afterFile);
   if (!prev) {
-    console.log('No previous run of the same tier found to compare against.');
+    console.log('同じ tier の比較対象となる直前実行が見つかりません。');
     process.exit(0);
   }
   beforeFile = prev;
@@ -84,12 +84,12 @@ const afterResult = loadResult(afterFile);
 
 // Warn if different tiers
 if (beforeResult.tier !== afterResult.tier) {
-  console.warn(`Warning: comparing different tiers (${beforeResult.tier} vs ${afterResult.tier})`);
+  console.warn(`警告: 異なる tier を比較しています（${beforeResult.tier} vs ${afterResult.tier}）`);
 }
 
 // Warn on schema mismatch
 if (beforeResult.schema_version !== afterResult.schema_version) {
-  console.warn(`Warning: schema version mismatch (${beforeResult.schema_version} vs ${afterResult.schema_version})`);
+  console.warn(`警告: schema version が一致しません（${beforeResult.schema_version} vs ${afterResult.schema_version}）`);
 }
 
 const comparison = compareEvalResults(beforeResult, afterResult, beforeFile, afterFile);

--- a/scripts/eval-list.ts
+++ b/scripts/eval-list.ts
@@ -28,12 +28,12 @@ let files: string[];
 try {
   files = fs.readdirSync(EVAL_DIR).filter(f => f.endsWith('.json'));
 } catch {
-  console.log('No eval runs yet. Run: EVALS=1 bun run test:evals');
+  console.log('Eval 実行履歴がありません。実行: EVALS=1 bun run test:evals');
   process.exit(0);
 }
 
 if (files.length === 0) {
-  console.log('No eval runs yet. Run: EVALS=1 bun run test:evals');
+  console.log('Eval 実行履歴がありません。実行: EVALS=1 bun run test:evals');
   process.exit(0);
 }
 
@@ -76,7 +76,7 @@ const displayed = runs.slice(0, limit);
 
 // Print table
 console.log('');
-console.log(`Eval History (${runs.length} total runs)`);
+console.log(`Eval 履歴（全 ${runs.length} 件）`);
 console.log('═'.repeat(90));
 console.log(
   '  ' +
@@ -100,6 +100,6 @@ for (const run of displayed) {
 console.log('─'.repeat(90));
 
 const totalCost = runs.reduce((s, r) => s + r.cost, 0);
-console.log(`  ${runs.length} runs | Total spend: $${totalCost.toFixed(2)} | Showing: ${displayed.length}`);
-console.log(`  Dir: ${EVAL_DIR}`);
+console.log(`  ${runs.length} 件 | 合計コスト: $${totalCost.toFixed(2)} | 表示件数: ${displayed.length}`);
+console.log(`  ディレクトリ: ${EVAL_DIR}`);
 console.log('');

--- a/scripts/eval-summary.ts
+++ b/scripts/eval-summary.ts
@@ -16,12 +16,12 @@ let files: string[];
 try {
   files = fs.readdirSync(EVAL_DIR).filter(f => f.endsWith('.json'));
 } catch {
-  console.log('No eval runs yet. Run: EVALS=1 bun run test:evals');
+  console.log('Eval 実行履歴がありません。実行: EVALS=1 bun run test:evals');
   process.exit(0);
 }
 
 if (files.length === 0) {
-  console.log('No eval runs yet. Run: EVALS=1 bun run test:evals');
+  console.log('Eval 実行履歴がありません。実行: EVALS=1 bun run test:evals');
   process.exit(0);
 }
 
@@ -93,19 +93,19 @@ for (const stats of branchStats.values()) {
 
 // Print summary
 console.log('');
-console.log('Eval Summary');
+console.log('Eval サマリー');
 console.log('═'.repeat(60));
-console.log(`  Total runs:        ${results.length} (${e2eRuns.length} e2e, ${judgeRuns.length} llm-judge)`);
-console.log(`  Total spend:       $${totalCost.toFixed(2)}`);
-console.log(`  Avg cost/e2e:      $${avgE2ECost.toFixed(2)}`);
-console.log(`  Avg cost/judge:    $${avgJudgeCost.toFixed(2)}`);
+console.log(`  総実行数:          ${results.length}（e2e: ${e2eRuns.length}, llm-judge: ${judgeRuns.length}）`);
+console.log(`  合計コスト:        $${totalCost.toFixed(2)}`);
+console.log(`  平均コスト/e2e:    $${avgE2ECost.toFixed(2)}`);
+console.log(`  平均コスト/judge:  $${avgJudgeCost.toFixed(2)}`);
 if (avgDetection !== null) {
-  console.log(`  Avg detection:     ${avgDetection.toFixed(1)} bugs`);
+  console.log(`  平均検出数:        ${avgDetection.toFixed(1)} 件`);
 }
 console.log('─'.repeat(60));
 
 if (flakyTests.length > 0) {
-  console.log(`  Flaky tests (${flakyTests.length}):`);
+  console.log(`  Flaky テスト（${flakyTests.length} 件）:`);
   for (const name of flakyTests) {
     console.log(`    - ${name}`);
   }
@@ -113,11 +113,11 @@ if (flakyTests.length > 0) {
 }
 
 if (branchStats.size > 0) {
-  console.log('  Branches:');
+  console.log('  ブランチ別:');
   const sorted = [...branchStats.entries()].sort((a, b) => b[1].avgDetection - a[1].avgDetection);
   for (const [branch, stats] of sorted) {
-    const det = stats.detections.length > 0 ? ` avg det: ${stats.avgDetection.toFixed(1)}` : '';
-    console.log(`    ${branch.padEnd(30)} ${stats.runs} runs${det}`);
+    const det = stats.detections.length > 0 ? ` 平均検出: ${stats.avgDetection.toFixed(1)}` : '';
+    console.log(`    ${branch.padEnd(30)} ${stats.runs} 回${det}`);
   }
   console.log('─'.repeat(60));
 }
@@ -127,8 +127,8 @@ const timestamps = results.map(r => r.timestamp).filter(Boolean).sort();
 if (timestamps.length > 0) {
   const first = timestamps[0].replace('T', ' ').slice(0, 16);
   const last = timestamps[timestamps.length - 1].replace('T', ' ').slice(0, 16);
-  console.log(`  Date range: ${first} → ${last}`);
+  console.log(`  期間: ${first} → ${last}`);
 }
 
-console.log(`  Dir: ${EVAL_DIR}`);
+console.log(`  ディレクトリ: ${EVAL_DIR}`);
 console.log('');

--- a/scripts/eval-watch.ts
+++ b/scripts/eval-watch.ts
@@ -75,7 +75,7 @@ export function renderDashboard(heartbeat: HeartbeatData | null, partial: Partia
   const lines: string[] = [];
 
   if (!heartbeat && !partial) {
-    lines.push('E2E Watch — 実行中のランが見つかりません');
+    lines.push('E2E Watch — No active run detected（実行中のランが見つかりません）');
     lines.push('');
     lines.push(`Heartbeat: ${HEARTBEAT_PATH} (未検出)`);
     lines.push(`Partial:   ${PARTIAL_PATH} (未検出)`);
@@ -106,13 +106,13 @@ export function renderDashboard(heartbeat: HeartbeatData | null, partial: Partia
     const name = heartbeat.currentTest.length > 30
       ? heartbeat.currentTest.slice(0, 27) + '...'
       : heartbeat.currentTest.padEnd(30);
-    lines.push(` \u29D6 ${name}  ${formatDuration(heartbeat.elapsedSec).padStart(6)}  ターン ${heartbeat.turn}   直近: ${heartbeat.lastTool}`);
+    lines.push(` \u29D6 ${name}  ${formatDuration(heartbeat.elapsedSec).padStart(6)}  turn ${heartbeat.turn}（ターン）   直近: ${heartbeat.lastTool}`);
 
     // Stale detection
     const lastToolTime = new Date(heartbeat.lastToolAt).getTime();
     const staleSec = Math.round((Date.now() - lastToolTime) / 1000);
     if (staleSec > STALE_THRESHOLD_SEC) {
-      lines.push(` \u26A0  停滞: 最後のツール呼び出しは ${formatDuration(staleSec)} 前です \u2014 ランが停止している可能性があります`);
+      lines.push(` \u26A0  STALE: last tool call was ${formatDuration(staleSec)} ago \u2014 run may have crashed（停滞の可能性）`);
     }
   }
 

--- a/scripts/eval-watch.ts
+++ b/scripts/eval-watch.ts
@@ -75,12 +75,12 @@ export function renderDashboard(heartbeat: HeartbeatData | null, partial: Partia
   const lines: string[] = [];
 
   if (!heartbeat && !partial) {
-    lines.push('E2E Watch — No active run detected');
+    lines.push('E2E Watch — 実行中のランが見つかりません');
     lines.push('');
-    lines.push(`Heartbeat: ${HEARTBEAT_PATH} (not found)`);
-    lines.push(`Partial:   ${PARTIAL_PATH} (not found)`);
+    lines.push(`Heartbeat: ${HEARTBEAT_PATH} (未検出)`);
+    lines.push(`Partial:   ${PARTIAL_PATH} (未検出)`);
     lines.push('');
-    lines.push('Start a run with: EVALS=1 bun test test/skill-e2e.test.ts');
+    lines.push('実行開始コマンド: EVALS=1 bun test test/skill-e2e.test.ts');
     return lines.join('\n');
   }
 
@@ -95,7 +95,7 @@ export function renderDashboard(heartbeat: HeartbeatData | null, partial: Partia
       const icon = t.passed ? '\u2713' : '\u2717';
       const cost = `$${t.cost_usd.toFixed(2)}`;
       const dur = `${Math.round(t.duration_ms / 1000)}s`;
-      const turns = t.turns_used !== undefined ? `${t.turns_used} turns` : '';
+      const turns = t.turns_used !== undefined ? `${t.turns_used} ターン` : '';
       const name = t.name.length > 30 ? t.name.slice(0, 27) + '...' : t.name.padEnd(30);
       lines.push(` ${icon} ${name}  ${cost.padStart(6)}  ${dur.padStart(5)}  ${turns}`);
     }
@@ -106,13 +106,13 @@ export function renderDashboard(heartbeat: HeartbeatData | null, partial: Partia
     const name = heartbeat.currentTest.length > 30
       ? heartbeat.currentTest.slice(0, 27) + '...'
       : heartbeat.currentTest.padEnd(30);
-    lines.push(` \u29D6 ${name}  ${formatDuration(heartbeat.elapsedSec).padStart(6)}  turn ${heartbeat.turn}   last: ${heartbeat.lastTool}`);
+    lines.push(` \u29D6 ${name}  ${formatDuration(heartbeat.elapsedSec).padStart(6)}  ターン ${heartbeat.turn}   直近: ${heartbeat.lastTool}`);
 
     // Stale detection
     const lastToolTime = new Date(heartbeat.lastToolAt).getTime();
     const staleSec = Math.round((Date.now() - lastToolTime) / 1000);
     if (staleSec > STALE_THRESHOLD_SEC) {
-      lines.push(` \u26A0  STALE: last tool call was ${formatDuration(staleSec)} ago \u2014 run may have crashed`);
+      lines.push(` \u26A0  停滞: 最後のツール呼び出しは ${formatDuration(staleSec)} 前です \u2014 ランが停止している可能性があります`);
     }
   }
 
@@ -122,11 +122,11 @@ export function renderDashboard(heartbeat: HeartbeatData | null, partial: Partia
   const completedCount = partial?.tests?.length || 0;
   const totalCost = partial?.total_cost_usd || 0;
   const running = heartbeat?.status === 'running' ? 1 : 0;
-  lines.push(` Completed: ${completedCount}  Running: ${running}  Cost: $${totalCost.toFixed(2)}  Elapsed: ${formatDuration(elapsed)}`);
+  lines.push(` 完了: ${completedCount}  実行中: ${running}  コスト: $${totalCost.toFixed(2)}  経過: ${formatDuration(elapsed)}`);
 
   if (heartbeat?.runId) {
     const logPath = path.join(GSTACK_DEV_DIR, 'e2e-runs', heartbeat.runId, 'progress.log');
-    lines.push(` Logs: ${logPath}`);
+    lines.push(` ログ: ${logPath}`);
   }
 
   return lines.join('\n');
@@ -145,7 +145,7 @@ if (import.meta.main) {
     if (heartbeat?.pid && !isProcessAlive(heartbeat.pid)) {
       try { fs.unlinkSync(HEARTBEAT_PATH); } catch { /* already gone */ }
       process.stdout.write('\x1B[2J\x1B[H');
-      process.stdout.write(`Cleared stale heartbeat — PID ${heartbeat.pid} is no longer running.\n\n`);
+      process.stdout.write(`停滞した heartbeat を削除しました — PID ${heartbeat.pid} は動作していません。\n\n`);
       heartbeat = null;
     }
 
@@ -159,7 +159,7 @@ if (import.meta.main) {
       try {
         const content = fs.readFileSync(logPath, 'utf-8');
         const tail = content.split('\n').filter(l => l.trim()).slice(-10);
-        process.stdout.write('\nRecent progress:\n');
+        process.stdout.write('\n直近の進捗:\n');
         for (const line of tail) {
           process.stdout.write(line + '\n');
         }

--- a/scripts/skill-check.ts
+++ b/scripts/skill-check.ts
@@ -32,7 +32,7 @@ let hasErrors = false;
 
 // ─── Skills ─────────────────────────────────────────────────
 
-console.log('  Skills:');
+console.log('  スキル:');
 for (const file of SKILL_FILES) {
   const fullPath = path.join(ROOT, file);
   const result = validateSkill(fullPath);
@@ -48,21 +48,21 @@ for (const file of SKILL_FILES) {
 
   if (totalInvalid > 0 || totalSnapErrors > 0) {
     hasErrors = true;
-    console.log(`  \u274c ${file.padEnd(30)} — ${totalValid} valid, ${totalInvalid} invalid, ${totalSnapErrors} snapshot errors`);
+    console.log(`  \u274c ${file.padEnd(30)} — 有効 ${totalValid}, 無効 ${totalInvalid}, snapshot エラー ${totalSnapErrors}`);
     for (const inv of result.invalid) {
-      console.log(`      line ${inv.line}: unknown command '${inv.command}'`);
+      console.log(`      行 ${inv.line}: 不明なコマンド '${inv.command}'`);
     }
     for (const se of result.snapshotFlagErrors) {
-      console.log(`      line ${se.command.line}: ${se.error}`);
+      console.log(`      行 ${se.command.line}: ${se.error}`);
     }
   } else {
-    console.log(`  \u2705 ${file.padEnd(30)} — ${totalValid} commands, all valid`);
+    console.log(`  \u2705 ${file.padEnd(30)} — ${totalValid} コマンド、すべて有効`);
   }
 }
 
 // ─── Templates ──────────────────────────────────────────────
 
-console.log('\n  Templates:');
+console.log('\n  テンプレート:');
 const TEMPLATES = [
   { tmpl: 'SKILL.md.tmpl', output: 'SKILL.md' },
   { tmpl: 'browse/SKILL.md.tmpl', output: 'browse/SKILL.md' },
@@ -72,12 +72,12 @@ for (const { tmpl, output } of TEMPLATES) {
   const tmplPath = path.join(ROOT, tmpl);
   const outPath = path.join(ROOT, output);
   if (!fs.existsSync(tmplPath)) {
-    console.log(`  \u26a0\ufe0f  ${output.padEnd(30)} — no template`);
+    console.log(`  \u26a0\ufe0f  ${output.padEnd(30)} — テンプレートなし`);
     continue;
   }
   if (!fs.existsSync(outPath)) {
     hasErrors = true;
-    console.log(`  \u274c ${output.padEnd(30)} — generated file missing! Run: bun run gen:skill-docs`);
+    console.log(`  \u274c ${output.padEnd(30)} — 生成済みファイルがありません。実行: bun run gen:skill-docs`);
     continue;
   }
   console.log(`  \u2705 ${tmpl.padEnd(30)} \u2192 ${output}`);
@@ -87,24 +87,24 @@ for (const { tmpl, output } of TEMPLATES) {
 for (const file of SKILL_FILES) {
   const tmplPath = path.join(ROOT, file + '.tmpl');
   if (!fs.existsSync(tmplPath) && !TEMPLATES.some(t => t.output === file)) {
-    console.log(`  \u26a0\ufe0f  ${file.padEnd(30)} — no template (OK if no $B commands)`);
+    console.log(`  \u26a0\ufe0f  ${file.padEnd(30)} — テンプレートなし（$B コマンドが無ければ問題なし）`);
   }
 }
 
 // ─── Freshness ──────────────────────────────────────────────
 
-console.log('\n  Freshness:');
+console.log('\n  鮮度チェック:');
 try {
   execSync('bun run scripts/gen-skill-docs.ts --dry-run', { cwd: ROOT, stdio: 'pipe' });
-  console.log('  \u2705 All generated files are fresh');
+  console.log('  \u2705 すべての生成ファイルは最新です');
 } catch (err: any) {
   hasErrors = true;
   const output = err.stdout?.toString() || '';
-  console.log('  \u274c Generated files are stale:');
+  console.log('  \u274c 生成ファイルが古いです:');
   for (const line of output.split('\n').filter((l: string) => l.startsWith('STALE'))) {
     console.log(`      ${line}`);
   }
-  console.log('      Run: bun run gen:skill-docs');
+  console.log('      実行: bun run gen:skill-docs');
 }
 
 console.log('');

--- a/setup
+++ b/setup
@@ -26,7 +26,7 @@ elif [ -f "$GSTACK_DIR/bun.lock" ] && [ "$GSTACK_DIR/bun.lock" -nt "$BROWSE_BIN"
 fi
 
 if [ "$NEEDS_BUILD" -eq 1 ]; then
-  echo "Building browse binary..."
+  echo "browse バイナリをビルドしています..."
   (
     cd "$GSTACK_DIR"
     bun install
@@ -39,13 +39,13 @@ if [ "$NEEDS_BUILD" -eq 1 ]; then
 fi
 
 if [ ! -x "$BROWSE_BIN" ]; then
-  echo "gstack setup failed: browse binary missing at $BROWSE_BIN" >&2
+  echo "gstack setup 失敗: browse バイナリが見つかりません ($BROWSE_BIN)" >&2
   exit 1
 fi
 
 # 2. Ensure Playwright's Chromium is available
 if ! ensure_playwright_browser; then
-  echo "Installing Playwright Chromium..."
+  echo "Playwright Chromium をインストールしています..."
   (
     cd "$GSTACK_DIR"
     bunx playwright install chromium
@@ -53,7 +53,7 @@ if ! ensure_playwright_browser; then
 fi
 
 if ! ensure_playwright_browser; then
-  echo "gstack setup failed: Playwright Chromium could not be launched" >&2
+  echo "gstack setup 失敗: Playwright Chromium を起動できませんでした" >&2
   exit 1
 fi
 
@@ -78,20 +78,20 @@ if [ "$SKILLS_BASENAME" = "skills" ]; then
     fi
   done
 
-  echo "gstack ready."
+  echo "gstack のセットアップが完了しました。"
   echo "  browse: $BROWSE_BIN"
   if [ ${#linked[@]} -gt 0 ]; then
-    echo "  linked skills: ${linked[*]}"
+    echo "  リンクした skills: ${linked[*]}"
   fi
 else
-  echo "gstack ready."
+  echo "gstack のセットアップが完了しました。"
   echo "  browse: $BROWSE_BIN"
-  echo "  (skipped skill symlinks — not inside .claude/skills/)"
+  echo "  （skill symlink はスキップしました: .claude/skills/ 配下ではありません）"
 fi
 
 # 4. First-time welcome + legacy cleanup
 if [ ! -d "$HOME/.gstack" ]; then
   mkdir -p "$HOME/.gstack"
-  echo "  Welcome! Run /gstack-upgrade anytime to stay current."
+  echo "  ようこそ！最新状態を保つには /gstack-upgrade を実行してください。"
 fi
 rm -f /tmp/gstack-latest-version


### PR DESCRIPTION
## Issue
- Closes #8
- Base target: `codex/translate`

## 変更概要
- `scripts/*` の eval/skill 補助スクリプト出力を日本語化
- `bin/*`, `setup`, `browse/bin/find-browse` のユーザー向けメッセージを日本語化
- 機械可読トークン（例: `UPGRADE_AVAILABLE`）や CLI リテラルは維持

## 検証
- `bash -n bin/dev-setup`
- `bash -n bin/dev-teardown`
- `bash -n bin/gstack-config`
- `bash -n browse/bin/find-browse`
- `bash -n setup`
- `bun test` はこの環境で `bun: command not found` のため未実施

## 残留リスク
- TypeScript スクリプトの実行検証は bun がある環境（CI/ローカル）で確認が必要