### PR TITLE
Issue #5: skill template日本語化（*.tmplのみ）

### DIFF
--- a/SKILL.md.tmpl
+++ b/SKILL.md.tmpl
@@ -2,11 +2,11 @@
 name: gstack
 version: 1.1.0
 description: |
-  Fast headless browser for QA testing and site dogfooding. Navigate any URL, interact with
-  elements, verify page state, diff before/after actions, take annotated screenshots, check
-  responsive layouts, test forms and uploads, handle dialogs, and assert element states.
-  ~100ms per command. Use when you need to test a feature, verify a deployment, dogfood a
-  user flow, or file a bug with evidence.
+  QA テストとサイト dogfooding 向けの高速 headless browser。任意の URL への移動、
+  要素操作、ページ状態確認、操作前後差分、注釈付きスクリーンショット取得、
+  レスポンシブ確認、フォーム/アップロード検証、ダイアログ処理、
+  要素状態アサーションに対応。1 コマンドあたり約 100ms。機能テスト、
+  デプロイ確認、ユーザーフロー dogfooding、証拠付きバグ報告で使う。
 allowed-tools:
   - Bash
   - Read
@@ -16,23 +16,23 @@ allowed-tools:
 
 {{UPDATE_CHECK}}
 
-# gstack browse: QA Testing & Dogfooding
+# gstack browse: QA テスト & Dogfooding
 
-Persistent headless Chromium. First call auto-starts (~3s), then ~100-200ms per command.
-Auto-shuts down after 30 min idle. State persists between calls (cookies, tabs, sessions).
+永続 headless Chromium。初回呼び出しで自動起動 (~3 秒) し、その後は 1 コマンドあたり約 100-200ms。
+30 分アイドルで自動終了。呼び出し間で状態（cookies、tabs、sessions）を保持する。
 
 {{BROWSE_SETUP}}
 
-## IMPORTANT
+## 重要
 
-- Use the compiled binary via Bash: `$B <command>`
-- NEVER use `mcp__claude-in-chrome__*` tools. They are slow and unreliable.
-- Browser persists between calls — cookies, login sessions, and tabs carry over.
-- Dialogs (alert/confirm/prompt) are auto-accepted by default — no browser lockup.
+- Bash からコンパイル済み binary を使う: `$B <command>`
+- `mcp__claude-in-chrome__*` は絶対に使わない。遅く不安定。
+- Browser は呼び出し間で状態を保持し、cookies / login sessions / tabs が引き継がれる。
+- Dialogs（alert/confirm/prompt）はデフォルトで自動 accept され、ブラウザが固まらない。
 
-## QA Workflows
+## QA ワークフロー
 
-### Test a user flow (login, signup, checkout, etc.)
+### ユーザーフローをテストする（login、signup、checkout など）
 
 ```bash
 # 1. Go to the page
@@ -52,7 +52,7 @@ $B is visible ".dashboard"  # assert the dashboard appeared
 $B screenshot /tmp/after-login.png
 ```
 
-### Verify a deployment / check prod
+### デプロイを検証する / prod を確認する
 
 ```bash
 $B goto https://yourapp.com
@@ -64,7 +64,7 @@ $B is visible ".hero-section"    # key elements present?
 $B screenshot /tmp/prod-check.png
 ```
 
-### Dogfood a feature end-to-end
+### 機能を end-to-end で dogfood する
 
 ```bash
 # Navigate to the feature
@@ -90,7 +90,7 @@ $B is checked "#agree-checkbox"
 $B console
 ```
 
-### Test responsive layouts
+### レスポンシブレイアウトをテストする
 
 ```bash
 # Quick: 3 screenshots at mobile/tablet/desktop
@@ -115,7 +115,7 @@ $B screenshot --clip 0,0,800,600 /tmp/above-fold.png
 $B screenshot --viewport /tmp/viewport.png
 ```
 
-### Test file upload
+### ファイルアップロードをテストする
 
 ```bash
 $B goto https://app.example.com/upload
@@ -125,7 +125,7 @@ $B is visible ".upload-success"
 $B screenshot /tmp/upload-result.png
 ```
 
-### Test forms with validation
+### バリデーション付きフォームをテストする
 
 ```bash
 $B goto https://app.example.com/form
@@ -142,7 +142,7 @@ $B click @e10
 $B snapshot -D                       # diff shows errors gone, success state
 ```
 
-### Test dialogs (delete confirmations, prompts)
+### ダイアログをテストする（削除確認、prompt）
 
 ```bash
 # Set up dialog handling BEFORE triggering
@@ -156,7 +156,7 @@ $B dialog-accept "my answer"  # accept with text
 $B click "#rename-button"     # triggers prompt
 ```
 
-### Test authenticated pages (import real browser cookies)
+### 認証済みページをテストする（実ブラウザ cookies を取り込む）
 
 ```bash
 # Import cookies from your real browser (opens interactive picker)
@@ -171,13 +171,13 @@ $B snapshot -i
 $B screenshot /tmp/github-profile.png
 ```
 
-### Compare two pages / environments
+### 2 つのページ / 環境を比較する
 
 ```bash
 $B diff https://staging.app.com https://prod.app.com
 ```
 
-### Multi-step chain (efficient for long flows)
+### 複数ステップ chain（長いフローを効率化）
 
 ```bash
 echo '[
@@ -191,7 +191,7 @@ echo '[
 ]' | $B chain
 ```
 
-## Quick Assertion Patterns
+## クイックアサーション・パターン
 
 ```bash
 # Element exists and is visible
@@ -227,17 +227,17 @@ $B css ".button" "background-color"
 
 {{SNAPSHOT_FLAGS}}
 
-## Command Reference
+## コマンドリファレンス
 
 {{COMMAND_REFERENCE}}
 
 ## Tips
 
-1. **Navigate once, query many times.** `goto` loads the page; then `text`, `js`, `screenshot` all hit the loaded page instantly.
-2. **Use `snapshot -i` first.** See all interactive elements, then click/fill by ref. No CSS selector guessing.
-3. **Use `snapshot -D` to verify.** Baseline → action → diff. See exactly what changed.
-4. **Use `is` for assertions.** `is visible .modal` is faster and more reliable than parsing page text.
-5. **Use `snapshot -a` for evidence.** Annotated screenshots are great for bug reports.
-6. **Use `snapshot -C` for tricky UIs.** Finds clickable divs that the accessibility tree misses.
-7. **Check `console` after actions.** Catch JS errors that don't surface visually.
-8. **Use `chain` for long flows.** Single command, no per-step CLI overhead.
+1. **1 回移動して何度も確認する。** `goto` でページを読み込んだ後、`text` / `js` / `screenshot` は即時実行できる。
+2. **最初に `snapshot -i` を使う。** 対話可能要素を見てから ref で click/fill する。CSS selector 推測は不要。
+3. **検証は `snapshot -D`。** baseline → action → diff で変化点を正確に確認できる。
+4. **アサーションには `is`。** `is visible .modal` はページ全文解析より速く堅牢。
+5. **証拠収集には `snapshot -a`。** 注釈付きスクリーンショットはバグ報告に有効。
+6. **難しい UI には `snapshot -C`。** accessibility tree が拾わない clickable div も見つかる。
+7. **操作後に `console` を確認。** 見た目に出ない JS エラーを拾える。
+8. **長いフローは `chain`。** 1 コマンドで実行し、ステップごとの CLI オーバーヘッドを減らせる。

--- a/browse/SKILL.md.tmpl
+++ b/browse/SKILL.md.tmpl
@@ -2,11 +2,11 @@
 name: browse
 version: 1.1.0
 description: |
-  Fast headless browser for QA testing and site dogfooding. Navigate any URL, interact with
-  elements, verify page state, diff before/after actions, take annotated screenshots, check
-  responsive layouts, test forms and uploads, handle dialogs, and assert element states.
-  ~100ms per command. Use when you need to test a feature, verify a deployment, dogfood a
-  user flow, or file a bug with evidence.
+  QA テストとサイト dogfooding 向けの高速ヘッドレスブラウザ。任意の URL へ移動し、
+  要素操作、ページ状態の確認、操作前後の差分確認、注釈付きスクリーンショット取得、
+  レスポンシブレイアウト確認、フォーム/アップロード検証、ダイアログ処理、
+  要素状態のアサーションを行える。1 コマンドあたり約 100ms。機能テスト、
+  デプロイ検証、ユーザーフローの dogfooding、根拠付きバグ報告が必要なときに使う。
 allowed-tools:
   - Bash
   - Read
@@ -16,16 +16,16 @@ allowed-tools:
 
 {{UPDATE_CHECK}}
 
-# browse: QA Testing & Dogfooding
+# browse: QA テスト & Dogfooding
 
-Persistent headless Chromium. First call auto-starts (~3s), then ~100ms per command.
-State persists between calls (cookies, tabs, login sessions).
+永続 headless Chromium。最初の呼び出しで自動起動 (~3 秒) し、その後は 1 コマンド約 100ms。
+呼び出し間で状態を保持する（cookies、tabs、login sessions）。
 
 {{BROWSE_SETUP}}
 
-## Core QA Patterns
+## 基本 QA パターン
 
-### 1. Verify a page loads correctly
+### 1. ページが正しく読み込まれるか確認する
 ```bash
 $B goto https://yourapp.com
 $B text                          # content loads?
@@ -34,7 +34,7 @@ $B network                       # failed requests?
 $B is visible ".main-content"    # key elements present?
 ```
 
-### 2. Test a user flow
+### 2. ユーザーフローをテストする
 ```bash
 $B goto https://app.com/login
 $B snapshot -i                   # see all interactive elements
@@ -45,27 +45,27 @@ $B snapshot -D                   # diff: what changed after submit?
 $B is visible ".dashboard"       # success state present?
 ```
 
-### 3. Verify an action worked
+### 3. 操作結果を検証する
 ```bash
 $B snapshot                      # baseline
 $B click @e3                     # do something
 $B snapshot -D                   # unified diff shows exactly what changed
 ```
 
-### 4. Visual evidence for bug reports
+### 4. バグ報告向けの視覚的エビデンスを残す
 ```bash
 $B snapshot -i -a -o /tmp/annotated.png   # labeled screenshot
 $B screenshot /tmp/bug.png                # plain screenshot
 $B console                                # error log
 ```
 
-### 5. Find all clickable elements (including non-ARIA)
+### 5. クリック可能要素をすべて見つける（non-ARIA 含む）
 ```bash
 $B snapshot -C                   # finds divs with cursor:pointer, onclick, tabindex
 $B click @c1                     # interact with them
 ```
 
-### 6. Assert element states
+### 6. 要素状態をアサートする
 ```bash
 $B is visible ".modal"
 $B is enabled "#submit-btn"
@@ -76,20 +76,20 @@ $B is focused "#search-input"
 $B js "document.body.textContent.includes('Success')"
 ```
 
-### 7. Test responsive layouts
+### 7. レスポンシブレイアウトをテストする
 ```bash
 $B responsive /tmp/layout        # mobile + tablet + desktop screenshots
 $B viewport 375x812              # or set specific viewport
 $B screenshot /tmp/mobile.png
 ```
 
-### 8. Test file uploads
+### 8. ファイルアップロードをテストする
 ```bash
 $B upload "#file-input" /path/to/file.pdf
 $B is visible ".upload-success"
 ```
 
-### 9. Test dialogs
+### 9. ダイアログをテストする
 ```bash
 $B dialog-accept "yes"           # set up handler
 $B click "#delete-button"        # trigger dialog
@@ -97,7 +97,7 @@ $B dialog                        # see what appeared
 $B snapshot -D                   # verify deletion happened
 ```
 
-### 10. Compare environments
+### 10. 環境を比較する
 ```bash
 $B diff https://staging.app.com https://prod.app.com
 ```
@@ -106,6 +106,6 @@ $B diff https://staging.app.com https://prod.app.com
 
 {{SNAPSHOT_FLAGS}}
 
-## Full Command List
+## 全コマンド一覧
 
 {{COMMAND_REFERENCE}}

--- a/gstack-upgrade/SKILL.md.tmpl
+++ b/gstack-upgrade/SKILL.md.tmpl
@@ -2,8 +2,8 @@
 name: gstack-upgrade
 version: 1.1.0
 description: |
-  Upgrade gstack to the latest version. Detects global vs vendored install,
-  runs the upgrade, and shows what's new.
+  gstack を最新バージョンへ更新する。global/vendored インストールを判定し、
+  アップグレード実行後に変更点を表示する。
 allowed-tools:
   - Bash
   - Read
@@ -13,15 +13,15 @@ allowed-tools:
 
 # /gstack-upgrade
 
-Upgrade gstack to the latest version and show what's new.
+gstack を最新バージョンへ更新し、変更点を表示する。
 
 ## Inline upgrade flow
 
-This section is referenced by all skill preambles when they detect `UPGRADE_AVAILABLE`.
+このセクションは、`UPGRADE_AVAILABLE` を検出した各 skill preamble から参照される。
 
-### Step 1: Ask the user (or auto-upgrade)
+### Step 1: ユーザー確認（または自動アップグレード）
 
-First, check if auto-upgrade is enabled:
+まず auto-upgrade が有効か確認する。
 ```bash
 _AUTO=""
 [ "${GSTACK_AUTO_UPGRADE:-}" = "1" ] && _AUTO="true"
@@ -29,21 +29,21 @@ _AUTO=""
 echo "AUTO_UPGRADE=$_AUTO"
 ```
 
-**If `AUTO_UPGRADE=true` or `AUTO_UPGRADE=1`:** Skip AskUserQuestion. Log "Auto-upgrading gstack v{old} → v{new}..." and proceed directly to Step 2. If `./setup` fails during auto-upgrade, restore from backup (`.bak` directory) and warn the user: "Auto-upgrade failed — restored previous version. Run `/gstack-upgrade` manually to retry."
+**`AUTO_UPGRADE=true` または `AUTO_UPGRADE=1` の場合:** AskUserQuestion を省略し、`Auto-upgrading gstack v{old} → v{new}...` をログして Step 2 へ進む。自動アップグレード中に `./setup` が失敗した場合はバックアップ（`.bak` ディレクトリ）から復元し、ユーザーへ `Auto-upgrade failed — restored previous version. Run /gstack-upgrade manually to retry.` と警告する。
 
-**Otherwise**, use AskUserQuestion:
+**それ以外** は AskUserQuestion を使う。
 - Question: "gstack **v{new}** is available (you're on v{old}). Upgrade now?"
 - Options: ["Yes, upgrade now", "Always keep me up to date", "Not now", "Never ask again"]
 
-**If "Yes, upgrade now":** Proceed to Step 2.
+**"Yes, upgrade now" の場合:** Step 2 へ進む。
 
-**If "Always keep me up to date":**
+**"Always keep me up to date" の場合:**
 ```bash
 ~/.claude/skills/gstack/bin/gstack-config set auto_upgrade true
 ```
-Tell user: "Auto-upgrade enabled. Future updates will install automatically." Then proceed to Step 2.
+ユーザーへ `Auto-upgrade enabled. Future updates will install automatically.` と伝え、Step 2 へ進む。
 
-**If "Not now":** Write snooze state with escalating backoff (first snooze = 24h, second = 48h, third+ = 1 week), then continue with the current skill. Do not mention the upgrade again.
+**"Not now" の場合:** 段階的バックオフ（1 回目 24h、2 回目 48h、3 回目以降 1 week）で snooze 状態を書き込み、現在の skill を続行する。アップグレードを再通知しない。
 ```bash
 _SNOOZE_FILE=~/.gstack/update-snoozed
 _REMOTE_VER="{new}"
@@ -59,18 +59,17 @@ _NEW_LEVEL=$((_CUR_LEVEL + 1))
 [ "$_NEW_LEVEL" -gt 3 ] && _NEW_LEVEL=3
 echo "$_REMOTE_VER $_NEW_LEVEL $(date +%s)" > "$_SNOOZE_FILE"
 ```
-Note: `{new}` is the remote version from the `UPGRADE_AVAILABLE` output — substitute it from the update check result.
+注: `{new}` は `UPGRADE_AVAILABLE` 出力の remote version。update check の結果で置換する。
 
-Tell user the snooze duration: "Next reminder in 24h" (or 48h or 1 week, depending on level). Tip: "Set `auto_upgrade: true` in `~/.gstack/config.yaml` for automatic upgrades."
+ユーザーへ snooze 期間を伝える（`Next reminder in 24h` / `48h` / `1 week`）。補足として、`~/.gstack/config.yaml` の `auto_upgrade: true` で自動アップグレードを有効化できることを案内する。
 
-**If "Never ask again":**
+**"Never ask again" の場合:**
 ```bash
 ~/.claude/skills/gstack/bin/gstack-config set update_check false
 ```
-Tell user: "Update checks disabled. Run `~/.claude/skills/gstack/bin/gstack-config set update_check true` to re-enable."
-Continue with the current skill.
+ユーザーへ `Update checks disabled. Run ~/.claude/skills/gstack/bin/gstack-config set update_check true to re-enable.` と伝え、現在の skill を続行する。
 
-### Step 2: Detect install type
+### Step 2: インストール種別を判定
 
 ```bash
 if [ -d "$HOME/.claude/skills/gstack/.git" ]; then
@@ -92,15 +91,15 @@ fi
 echo "Install type: $INSTALL_TYPE at $INSTALL_DIR"
 ```
 
-### Step 3: Save old version
+### Step 3: 旧バージョンを保存
 
 ```bash
 OLD_VERSION=$(cat "$INSTALL_DIR/VERSION" 2>/dev/null || echo "unknown")
 ```
 
-### Step 4: Upgrade
+### Step 4: アップグレード
 
-**For git installs** (global-git, local-git):
+**git install の場合**（global-git, local-git）:
 ```bash
 cd "$INSTALL_DIR"
 STASH_OUTPUT=$(git stash 2>&1)
@@ -108,9 +107,9 @@ git fetch origin
 git reset --hard origin/main
 ./setup
 ```
-If `$STASH_OUTPUT` contains "Saved working directory", warn the user: "Note: local changes were stashed. Run `git stash pop` in the skill directory to restore them."
+`$STASH_OUTPUT` に `Saved working directory` が含まれる場合は、`Note: local changes were stashed. Run git stash pop in the skill directory to restore them.` とユーザーへ警告する。
 
-**For vendored installs** (vendored, vendored-global):
+**vendored install の場合**（vendored, vendored-global）:
 ```bash
 PARENT=$(dirname "$INSTALL_DIR")
 TMP_DIR=$(mktemp -d)
@@ -121,9 +120,9 @@ cd "$INSTALL_DIR" && ./setup
 rm -rf "$INSTALL_DIR.bak" "$TMP_DIR"
 ```
 
-### Step 4.5: Sync local vendored copy
+### Step 4.5: ローカル vendored copy を同期
 
-After upgrading the primary install, check if there's also a local copy in the current project that needs updating:
+primary install のアップグレード後、現在の project に更新対象のローカル copy があるか確認する。
 
 ```bash
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -138,7 +137,7 @@ fi
 echo "LOCAL_GSTACK=$LOCAL_GSTACK"
 ```
 
-If `LOCAL_GSTACK` is non-empty, update it by copying from the freshly-upgraded primary install (same approach as README vendored install):
+`LOCAL_GSTACK` が空でない場合、アップグレード済み primary install からコピーして更新する（README の vendored install と同じ方式）。
 ```bash
 mv "$LOCAL_GSTACK" "$LOCAL_GSTACK.bak"
 cp -Rf "$INSTALL_DIR" "$LOCAL_GSTACK"
@@ -146,9 +145,9 @@ rm -rf "$LOCAL_GSTACK/.git"
 cd "$LOCAL_GSTACK" && ./setup
 rm -rf "$LOCAL_GSTACK.bak"
 ```
-Tell user: "Also updated vendored copy at `$LOCAL_GSTACK` — commit `.claude/skills/gstack/` when you're ready."
+ユーザーへ `Also updated vendored copy at $LOCAL_GSTACK — commit .claude/skills/gstack/ when you're ready.` と伝える。
 
-### Step 5: Write marker + clear cache
+### Step 5: marker 書き込み + cache クリア
 
 ```bash
 mkdir -p ~/.gstack
@@ -157,9 +156,9 @@ rm -f ~/.gstack/last-update-check
 rm -f ~/.gstack/update-snoozed
 ```
 
-### Step 6: Show What's New
+### Step 6: What's New を表示
 
-Read `$INSTALL_DIR/CHANGELOG.md`. Find all version entries between the old version and the new version. Summarize as 5-7 bullets grouped by theme. Don't overwhelm — focus on user-facing changes. Skip internal refactors unless they're significant.
+`$INSTALL_DIR/CHANGELOG.md` を読み、旧バージョンから新バージョンまでのエントリを抽出する。テーマごとに 5-7 個の箇条書きで要約する。過度に詳述せず、user-facing な変更を優先し、重要でない内部リファクタは省略する。
 
 Format:
 ```
@@ -173,12 +172,12 @@ What's new:
 Happy shipping!
 ```
 
-### Step 7: Continue
+### Step 7: 続行
 
-After showing What's New, continue with whatever skill the user originally invoked. The upgrade is done — no further action needed.
+What's New を表示したら、ユーザーが元々呼び出した skill を続行する。アップグレード完了後に追加作業は不要。
 
 ---
 
 ## Standalone usage
 
-When invoked directly as `/gstack-upgrade` (not from a preamble), follow Steps 2-6 above. If already on the latest version, tell the user: "You're already on the latest version (v{version})."
+`/gstack-upgrade` を単体実行した場合（preamble 経由ではない場合）は Step 2-6 を実行する。すでに最新なら `You're already on the latest version (v{version}).` と伝える。

--- a/plan-ceo-review/SKILL.md.tmpl
+++ b/plan-ceo-review/SKILL.md.tmpl
@@ -2,10 +2,10 @@
 name: plan-ceo-review
 version: 1.0.0
 description: |
-  CEO/founder-mode plan review. Rethink the problem, find the 10-star product,
-  challenge premises, expand scope when it creates a better product. Three modes:
-  SCOPE EXPANSION (dream big), HOLD SCOPE (maximum rigor), SCOPE REDUCTION
-  (strip to essentials).
+  CEO/founder-mode の plan review。課題定義を再考し、10-star product 視点で前提を疑い、
+  より良い成果につながる場合は scope を拡張する。3 モード:
+  SCOPE EXPANSION（大きく広げる）、HOLD SCOPE（最大限の厳密さ）、
+  SCOPE REDUCTION（本質へ絞る）。
 allowed-tools:
   - Read
   - Grep
@@ -19,13 +19,13 @@ allowed-tools:
 # Mega Plan Review Mode
 
 ## Philosophy
-You are not here to rubber-stamp this plan. You are here to make it extraordinary, catch every landmine before it explodes, and ensure that when this ships, it ships at the highest possible standard.
-But your posture depends on what the user needs:
+この plan を追認するだけで終わってはいけない。目的は、計画を卓越した水準に引き上げ、地雷を事前に除去し、出荷時品質を最大化すること。
+ただし姿勢はユーザーが求めるモードに従う:
 * SCOPE EXPANSION: You are building a cathedral. Envision the platonic ideal. Push scope UP. Ask "what would make this 10x better for 2x the effort?" The answer to "should we also build X?" is "yes, if it serves the vision." You have permission to dream.
 * HOLD SCOPE: You are a rigorous reviewer. The plan's scope is accepted. Your job is to make it bulletproof — catch every failure mode, test every edge case, ensure observability, map every error path. Do not silently reduce OR expand.
 * SCOPE REDUCTION: You are a surgeon. Find the minimum viable version that achieves the core outcome. Cut everything else. Be ruthless.
-Critical rule: Once the user selects a mode, COMMIT to it. Do not silently drift toward a different mode. If EXPANSION is selected, do not argue for less work during later sections. If REDUCTION is selected, do not sneak scope back in. Raise concerns once in Step 0 — after that, execute the chosen mode faithfully.
-Do NOT make any code changes. Do NOT start implementation. Your only job right now is to review the plan with maximum rigor and the appropriate level of ambition.
+Critical rule: ユーザーがモードを選んだら必ず従う。別モードへ暗黙に逸脱しない。EXPANSION 選択時は後段で縮小提案を続けず、REDUCTION 選択時は scope を戻さない。懸念提示は Step 0 で一度だけ行い、その後は選択モードを忠実に実行する。
+コード変更や実装開始は行わない。ここでの役割は、適切な野心レベルで plan を最大限厳密にレビューすること。
 
 ## Prime Directives
 1. Zero silent failures. Every failure mode must be visible — to the system, to the team, to the user. If a failure can happen silently, that is a critical defect in the plan.
@@ -38,7 +38,7 @@ Do NOT make any code changes. Do NOT start implementation. Your only job right n
 8. Optimize for the 6-month future, not just today. If this plan solves today's problem but creates next quarter's nightmare, say so explicitly.
 9. You have permission to say "scrap it and do this instead." If there's a fundamentally better approach, table it. I'd rather hear it now.
 
-## Engineering Preferences (use these to guide every recommendation)
+## Engineering Preferences（推奨判断の基準）
 * DRY is important — flag repetition aggressively.
 * Well-tested code is non-negotiable; I'd rather have too many tests than too few.
 * I want code that's "engineered enough" — not under-engineered (fragile, hacky) and not over-engineered (premature abstraction, unnecessary complexity).
@@ -55,9 +55,9 @@ Do NOT make any code changes. Do NOT start implementation. Your only job right n
 Step 0 > System audit > Error/rescue map > Test diagram > Failure modes > Opinionated recommendations > Everything else.
 Never skip Step 0, the system audit, the error/rescue map, or the failure modes section. These are the highest-leverage outputs.
 
-## PRE-REVIEW SYSTEM AUDIT (before Step 0)
-Before doing anything else, run a system audit. This is not the plan review — it is the context you need to review the plan intelligently.
-Run the following commands:
+## PRE-REVIEW SYSTEM AUDIT（Step 0 前）
+開始前に system audit を実行する。これは plan review 本体ではなく、レビュー品質を高めるための前提コンテキスト収集である。
+次のコマンドを実行する:
 ```
 git log --oneline -30                          # Recent history
 git diff main --stat                           # What's already changed
@@ -65,13 +65,13 @@ git stash list                                 # Any stashed work
 grep -r "TODO\|FIXME\|HACK\|XXX" --include="*.rb" --include="*.js" -l
 find . -name "*.rb" -newer Gemfile.lock | head -20  # Recently touched files
 ```
-Then read CLAUDE.md, TODOS.md, and any existing architecture docs. When reading TODOS.md, specifically:
+次に CLAUDE.md、TODOS.md、既存 architecture docs を読む。TODOS.md では特に次を確認する:
 * Note any TODOs this plan touches, blocks, or unlocks
 * Check if deferred work from prior reviews relates to this plan
 * Flag dependencies: does this plan enable or depend on deferred items?
 * Map known pain points (from TODOS) to this plan's scope
 
-Map:
+整理して示す:
 * What is the current system state?
 * What is already in flight (other open PRs, branches, stashed changes)?
 * What are the existing known pain points most relevant to this plan?
@@ -80,7 +80,7 @@ Map:
 ### Retrospective Check
 Check the git log for this branch. If there are prior commits suggesting a previous review cycle (review-driven refactors, reverted changes), note what was changed and whether the current plan re-touches those areas. Be MORE aggressive reviewing areas that were previously problematic. Recurring problem areas are architectural smells — surface them as architectural concerns.
 
-### Taste Calibration (EXPANSION mode only)
+### Taste Calibration（EXPANSION mode のみ）
 Identify 2-3 files or patterns in the existing codebase that are particularly well-designed. Note them as style references for the review. Also note 1-2 patterns that are frustrating or poorly designed — these are anti-patterns to avoid repeating.
 Report findings before proceeding to Step 0.
 
@@ -116,7 +116,7 @@ Describe the ideal end state of this system 12 months from now. Does this plan m
 1. Ruthless cut: What is the absolute minimum that ships value to a user? Everything else is deferred. No exceptions.
 2. What can be a follow-up PR? Separate "must ship together" from "nice to ship together."
 
-### 0E. Temporal Interrogation (EXPANSION and HOLD modes)
+### 0E. Temporal Interrogation（EXPANSION/HOLD）
 Think ahead to implementation: What decisions will need to be made during implementation that should be resolved NOW in the plan?
 ```
   HOUR 1 (foundations):     What does the implementer need to know?
@@ -142,7 +142,7 @@ Context-dependent defaults:
 Once selected, commit fully. Do not silently drift.
 **STOP.** AskUserQuestion once per issue. Do NOT batch. Recommend + WHY. If no issues or fix is obvious, state what you'll do and move on — don't waste a question. Do NOT proceed until user responds.
 
-## Review Sections (10 sections, after scope and mode are agreed)
+## Review Sections（scope/mode 合意後の 10 セクション）
 
 ### Section 1: Architecture Review
 Evaluate and diagram:
@@ -355,7 +355,7 @@ Evaluate:
 * Platform potential. Does this create capabilities other features can leverage?
 **STOP.** AskUserQuestion once per issue. Do NOT batch. Recommend + WHY. If no issues or fix is obvious, state what you'll do and move on — don't waste a question. Do NOT proceed until user responds.
 
-## CRITICAL RULE — How to ask questions
+## CRITICAL RULE — 質問方法
 Every AskUserQuestion MUST: (1) present 2-3 concrete lettered options, (2) state which option you recommend FIRST, (3) explain in 1-2 sentences WHY that option over the others, mapping to engineering preferences. No batching multiple issues into one question. No yes/no questions. Open-ended questions are allowed ONLY when you have genuine ambiguity about developer intent, architecture direction, 12-month goals, or what the end user wants — and you must explain what specifically is ambiguous.
 
 ## For Each Issue You Find
@@ -379,7 +379,7 @@ List existing code/flows that partially solve sub-problems and whether the plan 
 ### "Dream state delta" section
 Where this plan leaves us relative to the 12-month ideal.
 
-### Error & Rescue Registry (from Section 2)
+### Error & Rescue Registry（Section 2 由来）
 Complete table of every method that can fail, every exception class, rescued status, rescue action, user impact.
 
 ### Failure Modes Registry
@@ -404,10 +404,10 @@ For each TODO, describe:
 
 Then present options: **A)** Add to TODOS.md **B)** Skip — not valuable enough **C)** Build it now in this PR instead of deferring.
 
-### Delight Opportunities (EXPANSION mode only)
+### Delight Opportunities（EXPANSION mode のみ）
 Identify at least 5 "bonus chunk" opportunities (<30 min each) that would make users think "oh nice, they thought of that." Present each delight opportunity as its own individual AskUserQuestion. Never batch them. For each one, describe what it is, why it would delight users, and effort estimate. Then present options: **A)** Add to TODOS.md as a vision item **B)** Skip **C)** Build it now in this PR.
 
-### Diagrams (mandatory, produce all that apply)
+### Diagrams（必須、該当するものをすべて出す）
 1. System architecture
 2. Data flow (including shadow paths)
 3. State machine

--- a/plan-eng-review/SKILL.md.tmpl
+++ b/plan-eng-review/SKILL.md.tmpl
@@ -2,9 +2,9 @@
 name: plan-eng-review
 version: 1.0.0
 description: |
-  Eng manager-mode plan review. Lock in the execution plan — architecture,
-  data flow, diagrams, edge cases, test coverage, performance. Walks through
-  issues interactively with opinionated recommendations.
+  Eng manager-mode の plan review。architecture、data flow、diagrams、
+  edge cases、test coverage、performance を固め、意図を持った推奨付きで
+  対話的に issue をレビューする。
 allowed-tools:
   - Read
   - Grep
@@ -17,12 +17,12 @@ allowed-tools:
 
 # Plan Review Mode
 
-Review this plan thoroughly before making any code changes. For every issue or recommendation, explain the concrete tradeoffs, give me an opinionated recommendation, and ask for my input before assuming a direction.
+コード変更前に plan を徹底レビューする。各 issue / recommendation ごとに具体的な tradeoff を説明し、意図のある推奨を示し、方向を決める前にユーザーへ確認する。
 
 ## Priority hierarchy
-If you are running low on context or the user asks you to compress: Step 0 > Test diagram > Opinionated recommendations > Everything else. Never skip Step 0 or the test diagram.
+コンテキスト不足時や圧縮要求時は `Step 0 > Test diagram > Opinionated recommendations > その他` の順に優先する。Step 0 と test diagram は省略しない。
 
-## My engineering preferences (use these to guide your recommendations):
+## My engineering preferences（推奨判断の基準）
 * DRY is important—flag repetition aggressively.
 * Well-tested code is non-negotiable; I'd rather have too many tests than too few.
 * I want code that's "engineered enough" — not under-engineered (fragile, hacky) and not over-engineered (premature abstraction, unnecessary complexity).
@@ -30,31 +30,31 @@ If you are running low on context or the user asks you to compress: Step 0 > Tes
 * Bias toward explicit over clever.
 * Minimal diff: achieve the goal with the fewest new abstractions and files touched.
 
-## Documentation and diagrams:
+## Documentation and diagrams
 * I value ASCII art diagrams highly — for data flow, state machines, dependency graphs, processing pipelines, and decision trees. Use them liberally in plans and design docs.
 * For particularly complex designs or behaviors, embed ASCII diagrams directly in code comments in the appropriate places: Models (data relationships, state transitions), Controllers (request flow), Concerns (mixin behavior), Services (processing pipelines), and Tests (what's being set up and why) when the test structure is non-obvious.
 * **Diagram maintenance is part of the change.** When modifying code that has ASCII diagrams in comments nearby, review whether those diagrams are still accurate. Update them as part of the same commit. Stale diagrams are worse than no diagrams — they actively mislead. Flag any stale diagrams you encounter during review even if they're outside the immediate scope of the change.
 
-## BEFORE YOU START:
+## BEFORE YOU START
 
 ### Step 0: Scope Challenge
-Before reviewing anything, answer these questions:
+レビュー開始前に次へ回答する:
 1. **What existing code already partially or fully solves each sub-problem?** Can we capture outputs from existing flows rather than building parallel ones?
 2. **What is the minimum set of changes that achieves the stated goal?** Flag any work that could be deferred without blocking the core objective. Be ruthless about scope creep.
 3. **Complexity check:** If the plan touches more than 8 files or introduces more than 2 new classes/services, treat that as a smell and challenge whether the same goal can be achieved with fewer moving parts.
 4. **TODOS cross-reference:** Read `TODOS.md` if it exists. Are any deferred items blocking this plan? Can any deferred items be bundled into this PR without expanding scope? Does this plan create new work that should be captured as a TODO?
 
-Then ask if I want one of three options:
+次に、以下 3 つの options から選択を確認する:
 1. **SCOPE REDUCTION:** The plan is overbuilt. Propose a minimal version that achieves the core goal, then review that.
 2. **BIG CHANGE:** Work through interactively, one section at a time (Architecture → Code Quality → Tests → Performance) with at most 8 top issues per section.
 3. **SMALL CHANGE:** Compressed review — Step 0 + one combined pass covering all 4 sections. For each section, pick the single most important issue (think hard — this forces you to prioritize). Present as a single numbered list with lettered options + mandatory test diagram + completion summary. One AskUserQuestion round at the end. For each issue in the batch, state your recommendation and explain WHY, with lettered options.
 
-**Critical: If I do not select SCOPE REDUCTION, respect that decision fully.** Your job becomes making the plan I chose succeed, not continuing to lobby for a smaller plan. Raise scope concerns once in Step 0 — after that, commit to my chosen scope and optimize within it. Do not silently reduce scope, skip planned components, or re-argue for less work during later review sections.
+**Critical:** ユーザーが `SCOPE REDUCTION` を選ばない場合、その判断を尊重する。以降は選択された scope を成功させることに集中し、暗黙の縮小、計画項目の省略、再度の縮小提案を行わない。
 
-## Review Sections (after scope is agreed)
+## Review Sections（scope 合意後）
 
 ### 1. Architecture review
-Evaluate:
+評価観点:
 * Overall system design and component boundaries.
 * Dependency graph and coupling concerns.
 * Data flow patterns and potential bottlenecks.
@@ -66,7 +66,7 @@ Evaluate:
 **STOP.** For each issue found in this section, call AskUserQuestion individually. One issue per call. Present options, state your recommendation, explain WHY. Do NOT batch multiple issues into one AskUserQuestion. Only proceed to the next section after ALL issues in this section are resolved.
 
 ### 2. Code quality review
-Evaluate:
+評価観点:
 * Code organization and module structure.
 * DRY violations—be aggressive here.
 * Error handling patterns and missing edge cases (call these out explicitly).
@@ -84,7 +84,7 @@ For LLM/prompt changes: check the "Prompt/LLM changes" file patterns listed in C
 **STOP.** For each issue found in this section, call AskUserQuestion individually. One issue per call. Present options, state your recommendation, explain WHY. Do NOT batch multiple issues into one AskUserQuestion. Only proceed to the next section after ALL issues in this section are resolved.
 
 ### 4. Performance review
-Evaluate:
+評価観点:
 * N+1 queries and database access patterns.
 * Memory-usage concerns.
 * Caching opportunities.
@@ -92,11 +92,11 @@ Evaluate:
 
 **STOP.** For each issue found in this section, call AskUserQuestion individually. One issue per call. Present options, state your recommendation, explain WHY. Do NOT batch multiple issues into one AskUserQuestion. Only proceed to the next section after ALL issues in this section are resolved.
 
-## CRITICAL RULE — How to ask questions
+## CRITICAL RULE — 質問方法
 Every AskUserQuestion MUST: (1) present 2-3 concrete lettered options, (2) state which option you recommend FIRST, (3) explain in 1-2 sentences WHY that option over the others, mapping to engineering preferences. No batching multiple issues into one question. No yes/no questions. Open-ended questions are allowed ONLY when you have genuine ambiguity about developer intent, architecture direction, 12-month goals, or what the end user wants — and you must explain what specifically is ambiguous. **Exception:** SMALL CHANGE mode intentionally batches one issue per section into a single AskUserQuestion at the end — but each issue in that batch still requires its own recommendation + WHY + lettered options.
 
 ## For each issue you find
-For every specific issue (bug, smell, design concern, or risk):
+各 issue（bug、smell、design concern、risk）で次を守る:
 * **One issue = one AskUserQuestion call.** Never combine multiple issues into one question.
 * Describe the problem concretely, with file and line references.
 * Present 2–3 options, including "do nothing" where that's reasonable.

--- a/qa/SKILL.md.tmpl
+++ b/qa/SKILL.md.tmpl
@@ -2,11 +2,11 @@
 name: qa
 version: 1.0.0
 description: |
-  Systematically QA test a web application. Use when asked to "qa", "QA", "test this site",
-  "find bugs", "dogfood", or review quality. Four modes: diff-aware (automatic on feature
-  branches — analyzes git diff, identifies affected pages, tests them), full (systematic
-  exploration), quick (30-second smoke test), regression (compare against baseline). Produces
-  structured report with health score, screenshots, and repro steps.
+  Web アプリを体系的に QA テストする。`qa`, `QA`, `test this site`, `find bugs`,
+  `dogfood`, 品質レビュー依頼を受けたときに使う。4 つのモードを持つ:
+  diff-aware（feature branch で自動起動し、git diff から影響ページを特定して検証）、
+  full（網羅探索）、quick（30 秒スモークテスト）、regression（baseline 比較）。
+  health score、screenshots、repro steps を含む構造化レポートを生成する。
 allowed-tools:
   - Bash
   - Read
@@ -16,13 +16,13 @@ allowed-tools:
 
 {{UPDATE_CHECK}}
 
-# /qa: Systematic QA Testing
+# /qa: 体系的 QA テスト
 
-You are a QA engineer. Test web applications like a real user — click everything, fill every form, check every state. Produce a structured report with evidence.
+あなたは QA engineer。実ユーザー視点で web アプリを検証し、クリック、フォーム入力、状態遷移を確認する。必ず evidence 付きの構造化レポートを出力する。
 
 ## Setup
 
-**Parse the user's request for these parameters:**
+**ユーザー依頼から以下のパラメータを解釈する:**
 
 | Parameter | Default | Override example |
 |-----------|---------|-----------------|
@@ -32,13 +32,13 @@ You are a QA engineer. Test web applications like a real user — click everythi
 | Scope | Full app (or diff-scoped) | `Focus on the billing page` |
 | Auth | None | `Sign in to user@example.com`, `Import cookies from cookies.json` |
 
-**If no URL is given and you're on a feature branch:** Automatically enter **diff-aware mode** (see Modes below). This is the most common case — the user just shipped code on a branch and wants to verify it works.
+**URL 未指定かつ feature branch 上の場合:** 自動で **diff-aware mode** に入る（下記 Modes 参照）。これは最も一般的なケースで、branch 上での変更が動くかを確認する目的に対応する。
 
-**Find the browse binary:**
+**browse binary を見つける:**
 
 {{BROWSE_SETUP}}
 
-**Create output directories:**
+**出力ディレクトリを作成する:**
 
 ```bash
 REPORT_DIR=".gstack/qa-reports"
@@ -49,17 +49,17 @@ mkdir -p "$REPORT_DIR/screenshots"
 
 ## Modes
 
-### Diff-aware (automatic when on a feature branch with no URL)
+### Diff-aware（feature branch かつ URL 未指定時に自動）
 
-This is the **primary mode** for developers verifying their work. When the user says `/qa` without a URL and the repo is on a feature branch, automatically:
+開発者が変更確認するときの**主モード**。ユーザーが URL なしで `/qa` を実行し、repo が feature branch 上なら自動で次を実施する。
 
-1. **Analyze the branch diff** to understand what changed:
+1. **branch diff を解析**して変更内容を把握する:
    ```bash
    git diff main...HEAD --name-only
    git log main..HEAD --oneline
    ```
 
-2. **Identify affected pages/routes** from the changed files:
+2. **変更ファイルから影響ページ/ルートを特定**する:
    - Controller/route files → which URL paths they serve
    - View/template/component files → which pages render them
    - Model/service files → which pages use those models (check controllers that reference them)
@@ -67,40 +67,40 @@ This is the **primary mode** for developers verifying their work. When the user 
    - API endpoints → test them directly with `$B js "await fetch('/api/...')"`
    - Static pages (markdown, HTML) → navigate to them directly
 
-3. **Detect the running app** — check common local dev ports:
+3. **起動中アプリを検出**する（一般的なローカル dev port を確認）:
    ```bash
    $B goto http://localhost:3000 2>/dev/null && echo "Found app on :3000" || \
    $B goto http://localhost:4000 2>/dev/null && echo "Found app on :4000" || \
    $B goto http://localhost:8080 2>/dev/null && echo "Found app on :8080"
    ```
-   If no local app is found, check for a staging/preview URL in the PR or environment. If nothing works, ask the user for the URL.
+   ローカルアプリが見つからなければ PR や環境の staging/preview URL を確認し、それでも見つからない場合はユーザーへ URL を確認する。
 
-4. **Test each affected page/route:**
+4. **影響ページ/ルートごとにテストする:**
    - Navigate to the page
    - Take a screenshot
    - Check console for errors
    - If the change was interactive (forms, buttons, flows), test the interaction end-to-end
    - Use `snapshot -D` before and after actions to verify the change had the expected effect
 
-5. **Cross-reference with commit messages and PR description** to understand *intent* — what should the change do? Verify it actually does that.
+5. **commit message と PR description を照合**し、変更の意図（何を実現すべきか）を確認して実際の挙動と突き合わせる。
 
-6. **Check TODOS.md** (if it exists) for known bugs or issues related to the changed files. If a TODO describes a bug that this branch should fix, add it to your test plan. If you find a new bug during QA that isn't in TODOS.md, note it in the report.
+6. **TODOS.md を確認**し（存在する場合）、変更ファイルに関連する既知バグや課題をテスト計画へ反映する。QA 中に新規バグを見つけたらレポートへ記載する。
 
-7. **Report findings** scoped to the branch changes:
+7. **branch 変更にスコープした結果を報告**する:
    - "Changes tested: N pages/routes affected by this branch"
    - For each: does it work? Screenshot evidence.
    - Any regressions on adjacent pages?
 
-**If the user provides a URL with diff-aware mode:** Use that URL as the base but still scope testing to the changed files.
+**diff-aware で URL 指定がある場合:** その URL を基点にしつつ、検証範囲は変更ファイル由来に限定する。
 
-### Full (default when URL is provided)
-Systematic exploration. Visit every reachable page. Document 5-10 well-evidenced issues. Produce health score. Takes 5-15 minutes depending on app size.
+### Full (URL 指定時のデフォルト)
+体系探索モード。到達可能ページを訪問し、evidence が揃った 5-10 件の issue を記録する。health score を算出する。所要時間はアプリ規模により約 5-15 分。
 
 ### Quick (`--quick`)
-30-second smoke test. Visit homepage + top 5 navigation targets. Check: page loads? Console errors? Broken links? Produce health score. No detailed issue documentation.
+30 秒スモークテスト。ホーム + 上位 5 ナビ先を訪問し、読み込み、console errors、broken links を確認する。health score は出すが詳細 issue 記録は省略する。
 
 ### Regression (`--regression <baseline>`)
-Run full mode, then load `baseline.json` from a previous run. Diff: which issues are fixed? Which are new? What's the score delta? Append regression section to report.
+full mode 実行後に過去の `baseline.json` を読み込み、修正済み issue、新規 issue、score 差分を比較し、regression セクションをレポートへ追記する。
 
 ---
 
@@ -108,14 +108,14 @@ Run full mode, then load `baseline.json` from a previous run. Diff: which issues
 
 ### Phase 1: Initialize
 
-1. Find browse binary (see Setup above)
-2. Create output directories
-3. Copy report template from `qa/templates/qa-report-template.md` to output dir
-4. Start timer for duration tracking
+1. browse binary を見つける（Setup 参照）
+2. 出力ディレクトリを作成する
+3. `qa/templates/qa-report-template.md` を出力先へコピーする
+4. 計測用タイマーを開始する
 
-### Phase 2: Authenticate (if needed)
+### Phase 2: Authenticate（必要時）
 
-**If the user specified auth credentials:**
+**ユーザーが認証情報を指定した場合:**
 
 ```bash
 $B goto <login-url>
@@ -126,20 +126,20 @@ $B click @e5                      # submit
 $B snapshot -D                    # verify login succeeded
 ```
 
-**If the user provided a cookie file:**
+**ユーザーが cookie file を提供した場合:**
 
 ```bash
 $B cookie-import cookies.json
 $B goto <target-url>
 ```
 
-**If 2FA/OTP is required:** Ask the user for the code and wait.
+**2FA/OTP が必要な場合:** ユーザーへコードを確認して待機する。
 
-**If CAPTCHA blocks you:** Tell the user: "Please complete the CAPTCHA in the browser, then tell me to continue."
+**CAPTCHA でブロックされた場合:** `Please complete the CAPTCHA in the browser, then tell me to continue.` と伝える。
 
 ### Phase 3: Orient
 
-Get a map of the application:
+アプリ全体の地図を把握する:
 
 ```bash
 $B goto <target-url>
@@ -148,17 +148,17 @@ $B links                          # map navigation structure
 $B console --errors               # any errors on landing?
 ```
 
-**Detect framework** (note in report metadata):
+**framework を検出**し、report metadata に記録する:
 - `__next` in HTML or `_next/data` requests → Next.js
 - `csrf-token` meta tag → Rails
 - `wp-content` in URLs → WordPress
 - Client-side routing with no page reloads → SPA
 
-**For SPAs:** The `links` command may return few results because navigation is client-side. Use `snapshot -i` to find nav elements (buttons, menu items) instead.
+**SPA の場合:** ナビゲーションが client-side のため `links` の結果が少ないことがある。代わりに `snapshot -i` で nav 要素（buttons、menu items）を探す。
 
 ### Phase 4: Explore
 
-Visit pages systematically. At each page:
+ページを体系的に巡回する。各ページで次を実施する:
 
 ```bash
 $B goto <page-url>
@@ -166,7 +166,7 @@ $B snapshot -i -a -o "$REPORT_DIR/screenshots/page-name.png"
 $B console --errors
 ```
 
-Then follow the **per-page exploration checklist** (see `qa/references/issue-taxonomy.md`):
+続いて **per-page exploration checklist**（`qa/references/issue-taxonomy.md`）に従う:
 
 1. **Visual scan** — Look at the annotated screenshot for layout issues
 2. **Interactive elements** — Click buttons, links, controls. Do they work?
@@ -181,17 +181,17 @@ Then follow the **per-page exploration checklist** (see `qa/references/issue-tax
    $B viewport 1280x720
    ```
 
-**Depth judgment:** Spend more time on core features (homepage, dashboard, checkout, search) and less on secondary pages (about, terms, privacy).
+**深さの判断:** core feature（homepage、dashboard、checkout、search）を優先し、secondary page（about、terms、privacy）は簡潔に確認する。
 
-**Quick mode:** Only visit homepage + top 5 navigation targets from the Orient phase. Skip the per-page checklist — just check: loads? Console errors? Broken links visible?
+**Quick mode:** Orient で見つけた homepage + 上位 5 ナビ先のみ訪問し、per-page checklist は省略する。読み込み可否、console errors、broken links の有無のみ確認する。
 
 ### Phase 5: Document
 
-Document each issue **immediately when found** — don't batch them.
+issue は**発見次第すぐ**記録し、後でまとめて書かない。
 
-**Two evidence tiers:**
+**evidence は 2 段階で記録する:**
 
-**Interactive bugs** (broken flows, dead buttons, form failures):
+**Interactive bugs**（フロー破綻、dead buttons、form failure）:
 1. Take a screenshot before the action
 2. Perform the action
 3. Take a screenshot showing the result
@@ -205,7 +205,7 @@ $B screenshot "$REPORT_DIR/screenshots/issue-001-result.png"
 $B snapshot -D
 ```
 
-**Static bugs** (typos, layout issues, missing images):
+**Static bugs**（typos、layout issues、missing images）:
 1. Take a single annotated screenshot showing the problem
 2. Describe what's wrong
 
@@ -213,7 +213,7 @@ $B snapshot -D
 $B snapshot -i -a -o "$REPORT_DIR/screenshots/issue-002.png"
 ```
 
-**Write each issue to the report immediately** using the template format from `qa/templates/qa-report-template.md`.
+`qa/templates/qa-report-template.md` の形式で、issue ごとに即時レポートへ追記する。
 
 ### Phase 6: Wrap Up
 
@@ -233,7 +233,7 @@ $B snapshot -i -a -o "$REPORT_DIR/screenshots/issue-002.png"
    }
    ```
 
-**Regression mode:** After writing the report, load the baseline file. Compare:
+**Regression mode:** レポート作成後に baseline を読み込み、次を比較する:
 - Health score delta
 - Issues fixed (in baseline but not current)
 - New issues (in current but not baseline)
@@ -243,7 +243,7 @@ $B snapshot -i -a -o "$REPORT_DIR/screenshots/issue-002.png"
 
 ## Health Score Rubric
 
-Compute each category score (0-100), then take the weighted average.
+各カテゴリスコア（0-100）を算出し、重み付き平均を最終スコアとする。
 
 ### Console (weight: 15%)
 - 0 errors → 100
@@ -256,7 +256,7 @@ Compute each category score (0-100), then take the weighted average.
 - Each broken link → -15 (minimum 0)
 
 ### Per-Category Scoring (Visual, Functional, UX, Content, Performance, Accessibility)
-Each category starts at 100. Deduct per finding:
+各カテゴリは 100 点開始。issue ごとに減点する:
 - Critical issue → -25
 - High issue → -15
 - Medium issue → -8
@@ -308,22 +308,22 @@ Minimum 0 per category.
 
 ---
 
-## Important Rules
+## 重要ルール
 
-1. **Repro is everything.** Every issue needs at least one screenshot. No exceptions.
-2. **Verify before documenting.** Retry the issue once to confirm it's reproducible, not a fluke.
-3. **Never include credentials.** Write `[REDACTED]` for passwords in repro steps.
-4. **Write incrementally.** Append each issue to the report as you find it. Don't batch.
-5. **Never read source code.** Test as a user, not a developer.
-6. **Check console after every interaction.** JS errors that don't surface visually are still bugs.
-7. **Test like a user.** Use realistic data. Walk through complete workflows end-to-end.
-8. **Depth over breadth.** 5-10 well-documented issues with evidence > 20 vague descriptions.
-9. **Never delete output files.** Screenshots and reports accumulate — that's intentional.
-10. **Use `snapshot -C` for tricky UIs.** Finds clickable divs that the accessibility tree misses.
+1. **Repro が最重要。** すべての issue に最低 1 枚の screenshot を付ける。
+2. **記録前に再現確認。** 偶発ではなく再現性があることを 1 回再試行して確かめる。
+3. **認証情報を残さない。** パスワードは必ず `[REDACTED]` に置き換える。
+4. **逐次記録する。** issue は発見した順に追記し、まとめ書きしない。
+5. **ソースコードを読まない。** 開発者視点ではなくユーザー視点で検証する。
+6. **全操作後に console を確認。** 見た目に出ない JS エラーも不具合として扱う。
+7. **実利用データで検証。** end-to-end のワークフローを通して試す。
+8. **量より質。** 根拠が揃った 5-10 件の issue は、曖昧な 20 件より価値が高い。
+9. **出力ファイルを削除しない。** screenshots と reports を蓄積する運用を前提とする。
+10. **難しい UI には `snapshot -C`。** accessibility tree が拾わない clickable div を発見できる。
 
 ---
 
-## Output Structure
+## 出力構成
 
 ```
 .gstack/qa-reports/
@@ -336,4 +336,4 @@ Minimum 0 per category.
 └── baseline.json                          # For regression mode
 ```
 
-Report filenames use the domain and date: `qa-report-myapp-com-2026-03-12.md`
+レポートファイル名は domain と日付を使う: `qa-report-myapp-com-2026-03-12.md`

--- a/retro/SKILL.md.tmpl
+++ b/retro/SKILL.md.tmpl
@@ -2,9 +2,9 @@
 name: retro
 version: 2.0.0
 description: |
-  Weekly engineering retrospective. Analyzes commit history, work patterns,
-  and code quality metrics with persistent history and trend tracking.
-  Team-aware: breaks down per-person contributions with praise and growth areas.
+  週次 engineering retrospective。commit 履歴、作業パターン、コード品質指標を
+  永続履歴とトレンド追跡付きで分析する。team-aware で、各メンバーの貢献を
+  praise と growth area に分けて整理する。
 allowed-tools:
   - Bash
   - Read
@@ -17,10 +17,10 @@ allowed-tools:
 
 # /retro — Weekly Engineering Retrospective
 
-Generates a comprehensive engineering retrospective analyzing commit history, work patterns, and code quality metrics. Team-aware: identifies the user running the command, then analyzes every contributor with per-person praise and growth opportunities. Designed for a senior IC/CTO-level builder using Claude Code as a force multiplier.
+commit 履歴、作業パターン、コード品質指標を分析し、包括的な engineering retrospective を生成する。実行ユーザーを特定したうえで全 contributor を分析し、各人ごとの praise と growth opportunities を示す。Claude Code を活用する senior IC/CTO レベルの builder 向け。
 
 ## User-invocable
-When the user types `/retro`, run this skill.
+ユーザーが `/retro` と入力したらこの skill を実行する。
 
 ## Arguments
 - `/retro` — default: last 7 days
@@ -32,9 +32,9 @@ When the user types `/retro`, run this skill.
 
 ## Instructions
 
-Parse the argument to determine the time window. Default to 7 days if no argument given. Use `--since="N days ago"`, `--since="N hours ago"`, or `--since="N weeks ago"` (for `w` units) for git log queries. All times should be reported in **Pacific time** (use `TZ=America/Los_Angeles` when converting timestamps).
+引数を解析して time window を決定する。引数なしのデフォルトは 7 日。git log では `--since="N days ago"` / `--since="N hours ago"` / `--since="N weeks ago"`（`w` 単位）を使う。時刻はすべて **Pacific time**（変換時に `TZ=America/Los_Angeles`）で報告する。
 
-**Argument validation:** If the argument doesn't match a number followed by `d`, `h`, or `w`, the word `compare`, or `compare` followed by a number and `d`/`h`/`w`, show this usage and stop:
+**引数バリデーション:** 引数が `d` / `h` / `w` 付き数値、`compare`、または `compare` + `d`/`h`/`w` 付き数値に一致しない場合、次の usage を表示して停止する:
 ```
 Usage: /retro [window]
   /retro              — last 7 days (default)
@@ -45,9 +45,9 @@ Usage: /retro [window]
   /retro compare 14d  — compare with explicit window
 ```
 
-### Step 1: Gather Raw Data
+### Step 1: Raw Data を収集
 
-First, fetch origin and identify the current user:
+まず origin を fetch し、現在ユーザーを特定する:
 ```bash
 git fetch origin main --quiet
 # Identify who is running the retro
@@ -55,9 +55,9 @@ git config user.name
 git config user.email
 ```
 
-The name returned by `git config user.name` is **"you"** — the person reading this retro. All other authors are teammates. Use this to orient the narrative: "your" commits vs teammate contributions.
+`git config user.name` の結果は **"you"**（この retro の読者）として扱う。その他の author は teammate として扱い、「your commits vs teammate contributions」の観点で叙述する。
 
-Run ALL of these git commands in parallel (they are independent):
+以下の git コマンドは独立しているため、すべて並列実行する:
 
 ```bash
 # 1. All commits in window with timestamps, subject, hash, AUTHOR, files changed, insertions, deletions
@@ -91,7 +91,7 @@ cat ~/.gstack/greptile-history.md 2>/dev/null || true
 cat TODOS.md 2>/dev/null || true
 ```
 
-### Step 2: Compute Metrics
+### Step 2: Metrics を算出
 
 Calculate and present these metrics in a summary table:
 
@@ -230,7 +230,7 @@ For each contributor (including the current user), compute:
 
 **If there are Co-Authored-By trailers:** Parse `Co-Authored-By:` lines in commit messages. Credit those authors for the commit alongside the primary author. Note AI co-authors (e.g., `noreply@anthropic.com`) but do not include them as team members — instead, track "AI-assisted commits" as a separate metric.
 
-### Step 10: Week-over-Week Trends (if window >= 14d)
+### Step 10: Week-over-Week Trends（window >= 14d）
 
 If the time window is 14 days or more, split into weekly buckets and show trends:
 - Commits per week (total and per-author)
@@ -255,7 +255,7 @@ Count backward from today — how many consecutive days have at least one commit
 - "Team shipping streak: 47 consecutive days"
 - "Your shipping streak: 32 consecutive days"
 
-### Step 12: Load History & Compare
+### Step 12: History を読み込み比較
 
 Before saving the new snapshot, check for prior retro history:
 
@@ -276,7 +276,7 @@ Deep sessions:      3      →    5           ↑2
 
 **If no prior retros exist:** Skip the comparison section and append: "First retro recorded — run again next week to see trends."
 
-### Step 13: Save Retro History
+### Step 13: Retro History を保存
 
 After computing all metrics (including streak) and loading any prior history for comparison, save a JSON snapshot:
 
@@ -346,7 +346,7 @@ Include backlog data in the JSON when TODOS.md exists:
   }
 ```
 
-### Step 14: Write the Narrative
+### Step 14: Narrative を作成
 
 Structure the output as:
 
@@ -394,7 +394,7 @@ Narrative covering:
 - Focus score with interpretation
 - Ship of the week callout
 
-### Your Week (personal deep-dive)
+### Your Week（personal deep-dive）
 (from Step 9, for the current user only)
 
 This is the section the user cares most about. Include:
@@ -463,7 +463,7 @@ When the user runs `/retro compare` (or `/retro compare 14d`):
 - Use markdown tables and code blocks for data, prose for narrative
 - Output directly to the conversation — do NOT write to filesystem (except the `.context/retros/` JSON snapshot)
 
-## Important Rules
+## 重要ルール
 
 - ALL narrative output goes directly to the user in the conversation. The ONLY file written is the `.context/retros/` JSON snapshot.
 - Use `origin/main` for all git queries (not local main which may be stale)

--- a/review/SKILL.md.tmpl
+++ b/review/SKILL.md.tmpl
@@ -2,8 +2,8 @@
 name: review
 version: 1.0.0
 description: |
-  Pre-landing PR review. Analyzes diff against main for SQL safety, LLM trust
-  boundary violations, conditional side effects, and other structural issues.
+  Pre-landing PR review。main との差分を解析し、SQL 安全性、LLM trust boundary
+  違反、条件付き副作用、その他の構造的問題を検出する。
 allowed-tools:
   - Bash
   - Read
@@ -18,62 +18,62 @@ allowed-tools:
 
 # Pre-Landing PR Review
 
-You are running the `/review` workflow. Analyze the current branch's diff against main for structural issues that tests don't catch.
+`/review` workflow を実行する。現在 branch の main 差分を解析し、テストでは見落としやすい構造的問題を検出する。
 
 ---
 
-## Step 1: Check branch
+## Step 1: branch を確認
 
-1. Run `git branch --show-current` to get the current branch.
-2. If on `main`, output: **"Nothing to review — you're on main or have no changes against main."** and stop.
-3. Run `git fetch origin main --quiet && git diff origin/main --stat` to check if there's a diff. If no diff, output the same message and stop.
-
----
-
-## Step 2: Read the checklist
-
-Read `.claude/skills/review/checklist.md`.
-
-**If the file cannot be read, STOP and report the error.** Do not proceed without the checklist.
+1. `git branch --show-current` で現在 branch を取得する。
+2. `main` 上なら **`Nothing to review — you're on main or have no changes against main.`** を出力して停止する。
+3. `git fetch origin main --quiet && git diff origin/main --stat` で差分有無を確認し、差分がなければ同じメッセージで停止する。
 
 ---
 
-## Step 2.5: Check for Greptile review comments
+## Step 2: checklist を読む
 
-Read `.claude/skills/review/greptile-triage.md` and follow the fetch, filter, classify, and **escalation detection** steps.
+`.claude/skills/review/checklist.md` を読む。
 
-**If no PR exists, `gh` fails, API returns an error, or there are zero Greptile comments:** Skip this step silently. Greptile integration is additive — the review works without it.
-
-**If Greptile comments are found:** Store the classifications (VALID & ACTIONABLE, VALID BUT ALREADY FIXED, FALSE POSITIVE, SUPPRESSED) — you will need them in Step 5.
+**読めない場合は STOP し、エラーを報告する。** checklist なしで進めてはいけない。
 
 ---
 
-## Step 3: Get the diff
+## Step 2.5: Greptile review comments を確認
 
-Fetch the latest main to avoid false positives from a stale local main:
+`.claude/skills/review/greptile-triage.md` を読み、fetch / filter / classify / **escalation detection** を実行する。
+
+**PR がない、`gh` 失敗、API エラー、Greptile comment が 0 件の場合:** このステップを黙ってスキップする。Greptile 統合は加点要素であり、なくても review は成立する。
+
+**Greptile comment がある場合:** 分類（VALID & ACTIONABLE / VALID BUT ALREADY FIXED / FALSE POSITIVE / SUPPRESSED）を保持し、Step 5 で使う。
+
+---
+
+## Step 3: diff を取得
+
+古い local main 由来の誤検出を避けるため、最新 main を fetch する:
 
 ```bash
 git fetch origin main --quiet
 ```
 
-Run `git diff origin/main` to get the full diff. This includes both committed and uncommitted changes against the latest main.
+`git diff origin/main` で full diff を取得する。最新 main に対する committed / uncommitted の両方を含む。
 
 ---
 
-## Step 4: Two-pass review
+## Step 4: 2 パス review
 
-Apply the checklist against the diff in two passes:
+checklist を diff に対して 2 パスで適用する:
 
 1. **Pass 1 (CRITICAL):** SQL & Data Safety, LLM Output Trust Boundary
 2. **Pass 2 (INFORMATIONAL):** Conditional Side Effects, Magic Numbers & String Coupling, Dead Code & Consistency, LLM Prompt Issues, Test Gaps, View/Frontend
 
-Follow the output format specified in the checklist. Respect the suppressions — do NOT flag items listed in the "DO NOT flag" section.
+出力形式は checklist 指定に従う。suppressions を尊重し、`DO NOT flag` セクション記載項目は指摘しない。
 
 ---
 
-## Step 5: Output findings
+## Step 5: findings を出力
 
-**Always output ALL findings** — both critical and informational. The user must see every issue.
+**必ず全 findings を出力**する。critical / informational を問わず、ユーザーが全 issue を見られる状態にする。
 
 - If CRITICAL issues found: output all findings, then for EACH critical issue use a separate AskUserQuestion with the problem, your recommended fix, and options (A: Fix it now, B: Acknowledge, C: False positive — skip).
   After all critical questions are answered, output a summary of what the user chose for each issue. If the user chose A (fix) on any issue, apply the recommended fixes. If only B/C were chosen, no action needed.
@@ -110,20 +110,20 @@ Before replying to any comment, run the **Escalation Detection** algorithm from 
 
 ## Step 5.5: TODOS cross-reference
 
-Read `TODOS.md` in the repository root (if it exists). Cross-reference the PR against open TODOs:
+repository root の `TODOS.md`（存在する場合）を読み、PR と open TODO を突き合わせる:
 
 - **Does this PR close any open TODOs?** If yes, note which items in your output: "This PR addresses TODO: <title>"
 - **Does this PR create work that should become a TODO?** If yes, flag it as an informational finding.
 - **Are there related TODOs that provide context for this review?** If yes, reference them when discussing related findings.
 
-If TODOS.md doesn't exist, skip this step silently.
+TODOS.md が存在しない場合は黙ってスキップする。
 
 ---
 
-## Important Rules
+## 重要ルール
 
-- **Read the FULL diff before commenting.** Do not flag issues already addressed in the diff.
-- **Read-only by default.** Only modify files if the user explicitly chooses "Fix it now" on a critical issue. Never commit, push, or create PRs.
-- **Be terse.** One line problem, one line fix. No preamble.
-- **Only flag real problems.** Skip anything that's fine.
-- **Use Greptile reply templates from greptile-triage.md.** Every reply includes evidence. Never post vague replies.
+- **コメント前に FULL diff を読む。** すでに差分で解消済みの問題は指摘しない。
+- **デフォルトは read-only。** critical issue でユーザーが `Fix it now` を選んだ場合のみ修正し、commit / push / PR 作成は行わない。
+- **簡潔に書く。** 1 行で問題、1 行で修正。前置きは不要。
+- **実問題だけを指摘する。** 問題がない箇所はスキップする。
+- **Greptile 返信は greptile-triage.md のテンプレートを使う。** すべて evidence 付きで、曖昧な返信は禁止。

--- a/setup-browser-cookies/SKILL.md.tmpl
+++ b/setup-browser-cookies/SKILL.md.tmpl
@@ -2,9 +2,9 @@
 name: setup-browser-cookies
 version: 1.0.0
 description: |
-  Import cookies from your real browser (Comet, Chrome, Arc, Brave, Edge) into the
-  headless browse session. Opens an interactive picker UI where you select which
-  cookie domains to import. Use before QA testing authenticated pages.
+  実ブラウザ（Comet, Chrome, Arc, Brave, Edge）の cookies を headless browse
+  セッションへ取り込む。インポート対象ドメインを選ぶための対話式 picker UI を開く。
+  認証済みページを QA テストする前に使う。
 allowed-tools:
   - Bash
   - Read
@@ -15,59 +15,59 @@ allowed-tools:
 
 # Setup Browser Cookies
 
-Import logged-in sessions from your real Chromium browser into the headless browse session.
+実 Chromium ブラウザのログインセッションを headless browse セッションへ取り込む。
 
-## How it works
+## 動作概要
 
-1. Find the browse binary
-2. Run `cookie-import-browser` to detect installed browsers and open the picker UI
-3. User selects which cookie domains to import in their browser
-4. Cookies are decrypted and loaded into the Playwright session
+1. browse binary を見つける
+2. `cookie-import-browser` を実行し、インストール済みブラウザ検出と picker UI 起動を行う
+3. ユーザーがブラウザ上でインポート対象の cookie domain を選ぶ
+4. cookies を復号して Playwright セッションへ読み込む
 
-## Steps
+## 手順
 
-### 1. Find the browse binary
+### 1. browse binary を見つける
 
 {{BROWSE_SETUP}}
 
-### 2. Open the cookie picker
+### 2. cookie picker を開く
 
 ```bash
 $B cookie-import-browser
 ```
 
-This auto-detects installed Chromium browsers (Comet, Chrome, Arc, Brave, Edge) and opens
-an interactive picker UI in your default browser where you can:
-- Switch between installed browsers
-- Search domains
-- Click "+" to import a domain's cookies
-- Click trash to remove imported cookies
+インストール済み Chromium ブラウザ（Comet, Chrome, Arc, Brave, Edge）を自動検出し、
+デフォルトブラウザで対話式 picker UI を開く。UI では以下を実行できる。
+- インストール済みブラウザの切り替え
+- domain 検索
+- `+` をクリックして domain の cookies をインポート
+- ゴミ箱アイコンをクリックしてインポート済み cookies を削除
 
-Tell the user: **"Cookie picker opened — select the domains you want to import in your browser, then tell me when you're done."**
+ユーザーには次を伝える: **「Cookie picker を開きました。ブラウザでインポートしたい domain を選択し、完了したら知らせてください。」**
 
-### 3. Direct import (alternative)
+### 3. 直接インポート（代替）
 
-If the user specifies a domain directly (e.g., `/setup-browser-cookies github.com`), skip the UI:
+ユーザーが domain を直接指定した場合（例: `/setup-browser-cookies github.com`）は UI を省略する。
 
 ```bash
 $B cookie-import-browser comet --domain github.com
 ```
 
-Replace `comet` with the appropriate browser if specified.
+ブラウザ指定がある場合は `comet` を適切な名前へ置き換える。
 
-### 4. Verify
+### 4. 確認
 
-After the user confirms they're done:
+ユーザーが完了を通知したら実行する。
 
 ```bash
 $B cookies
 ```
 
-Show the user a summary of imported cookies (domain counts).
+インポート済み cookies の要約（domain ごとの件数）をユーザーに示す。
 
-## Notes
+## 注意点
 
-- First import per browser may trigger a macOS Keychain dialog — click "Allow" / "Always Allow"
-- Cookie picker is served on the same port as the browse server (no extra process)
-- Only domain names and cookie counts are shown in the UI — no cookie values are exposed
-- The browse session persists cookies between commands, so imported cookies work immediately
+- ブラウザごとの初回インポート時に macOS Keychain ダイアログが出る場合がある。`Allow` / `Always Allow` を選ぶ
+- Cookie picker は browse server と同一ポートで配信される（追加プロセスは不要）
+- UI には domain 名と cookie 件数のみを表示し、cookie 値は露出しない
+- browse session はコマンド間で cookies を保持するため、インポート直後から利用できる

--- a/ship/SKILL.md.tmpl
+++ b/ship/SKILL.md.tmpl
@@ -2,7 +2,8 @@
 name: ship
 version: 1.0.0
 description: |
-  Ship workflow: merge main, run tests, review diff, bump VERSION, update CHANGELOG, commit, push, create PR.
+  Ship workflow: main の merge、tests 実行、diff review、VERSION 更新、CHANGELOG 更新、
+  commit、push、PR 作成を自動で進める。
 allowed-tools:
   - Bash
   - Read
@@ -17,9 +18,9 @@ allowed-tools:
 
 # Ship: Fully Automated Ship Workflow
 
-You are running the `/ship` workflow. This is a **non-interactive, fully automated** workflow. Do NOT ask for confirmation at any step. The user said `/ship` which means DO IT. Run straight through and output the PR URL at the end.
+`/ship` workflow を実行する。これは **non-interactive / fully automated** workflow であり、各ステップで確認を取らない。ユーザーが `/ship` を実行したら、そのまま最後まで処理し、最終的に PR URL を出力する。
 
-**Only stop for:**
+**停止してよい条件:**
 - On `main` branch (abort)
 - Merge conflicts that can't be auto-resolved (stop, show conflicts)
 - Test failures (stop, show failures)
@@ -29,7 +30,7 @@ You are running the `/ship` workflow. This is a **non-interactive, fully automat
 - TODOS.md missing and user wants to create one (ask — see Step 5.5)
 - TODOS.md disorganized and user wants to reorganize (ask — see Step 5.5)
 
-**Never stop for:**
+**以下では停止しない:**
 - Uncommitted changes (always include them)
 - Version bump choice (auto-pick MICRO or PATCH — see Step 4)
 - CHANGELOG content (auto-generate from diff)
@@ -41,29 +42,29 @@ You are running the `/ship` workflow. This is a **non-interactive, fully automat
 
 ## Step 1: Pre-flight
 
-1. Check the current branch. If on `main`, **abort**: "You're on main. Ship from a feature branch."
+1. 現在 branch を確認し、`main` なら **abort**: `You're on main. Ship from a feature branch.`
 
-2. Run `git status` (never use `-uall`). Uncommitted changes are always included — no need to ask.
+2. `git status` を実行する（`-uall` は使わない）。uncommitted changes は常に含めるため確認不要。
 
-3. Run `git diff main...HEAD --stat` and `git log main..HEAD --oneline` to understand what's being shipped.
+3. `git diff main...HEAD --stat` と `git log main..HEAD --oneline` を実行し、出荷対象を把握する。
 
 ---
 
-## Step 2: Merge origin/main (BEFORE tests)
+## Step 2: origin/main を merge（tests 前）
 
-Fetch and merge `origin/main` into the feature branch so tests run against the merged state:
+tests を merged 状態で実行するため、feature branch に `origin/main` を取り込む:
 
 ```bash
 git fetch origin main && git merge origin/main --no-edit
 ```
 
-**If there are merge conflicts:** Try to auto-resolve if they are simple (VERSION, schema.rb, CHANGELOG ordering). If conflicts are complex or ambiguous, **STOP** and show them.
+**merge conflicts がある場合:** 単純なもの（VERSION、schema.rb、CHANGELOG 並び）は自動解決を試す。複雑または曖昧な競合は **STOP** して内容を提示する。
 
-**If already up to date:** Continue silently.
+**すでに up-to-date の場合:** そのまま続行する。
 
 ---
 
-## Step 3: Run tests (on merged code)
+## Step 3: tests を実行（merged code）
 
 **Do NOT run `RAILS_ENV=test bin/rails db:migrate`** — `bin/test-lane` already calls
 `db:test:prepare` internally, which loads the schema into the correct lane database.
@@ -77,25 +78,25 @@ npm run test 2>&1 | tee /tmp/ship_vitest.txt &
 wait
 ```
 
-After both complete, read the output files and check pass/fail.
+両方完了後、出力ファイルを読んで pass/fail を判定する。
 
-**If any test fails:** Show the failures and **STOP**. Do not proceed.
+**いずれかが失敗した場合:** 失敗内容を示して **STOP** する。
 
-**If all pass:** Continue silently — just note the counts briefly.
+**すべて成功した場合:** そのまま続行し、件数のみ簡潔に記録する。
 
 ---
 
-## Step 3.25: Eval Suites (conditional)
+## Step 3.25: Eval Suites（条件付き）
 
-Evals are mandatory when prompt-related files change. Skip this step entirely if no prompt files are in the diff.
+prompt 関連ファイルが変更された場合、eval は必須。差分に prompt ファイルがなければこのステップを完全にスキップする。
 
-**1. Check if the diff touches prompt-related files:**
+**1. diff が prompt 関連ファイルに触れているか確認:**
 
 ```bash
 git diff origin/main --name-only
 ```
 
-Match against these patterns (from CLAUDE.md):
+次のパターン（CLAUDE.md）に一致するか判定する:
 - `app/services/*_prompt_builder.rb`
 - `app/services/*_generation_service.rb`, `*_writer_service.rb`, `*_designer_service.rb`
 - `app/services/*_evaluator.rb`, `*_scorer.rb`, `*_classifier_service.rb`, `*_analyzer.rb`
@@ -104,9 +105,9 @@ Match against these patterns (from CLAUDE.md):
 - `config/system_prompts/*.txt`
 - `test/evals/**/*` (eval infrastructure changes affect all suites)
 
-**If no matches:** Print "No prompt-related files changed — skipping evals." and continue to Step 3.5.
+**一致なしの場合:** `No prompt-related files changed — skipping evals.` を出力して Step 3.5 へ進む。
 
-**2. Identify affected eval suites:**
+**2. 影響を受ける eval suites を特定:**
 
 Each eval runner (`test/evals/*_eval_runner.rb`) declares `PROMPT_SOURCE_FILES` listing which source files affect it. Grep these to find which suites match the changed files:
 
@@ -116,12 +117,12 @@ grep -l "changed_file_basename" test/evals/*_eval_runner.rb
 
 Map runner → test file: `post_generation_eval_runner.rb` → `post_generation_eval_test.rb`.
 
-**Special cases:**
+**特記事項:**
 - Changes to `test/evals/judges/*.rb`, `test/evals/support/*.rb`, or `test/evals/fixtures/` affect ALL suites that use those judges/support files. Check imports in the eval test files to determine which.
 - Changes to `config/system_prompts/*.txt` — grep eval runners for the prompt filename to find affected suites.
 - If unsure which suites are affected, run ALL suites that could plausibly be impacted. Over-testing is better than missing a regression.
 
-**3. Run affected suites at `EVAL_JUDGE_TIER=full`:**
+**3. 影響 suites を `EVAL_JUDGE_TIER=full` で実行:**
 
 `/ship` is a pre-merge gate, so always use full tier (Sonnet structural + Opus persona judges).
 
@@ -131,12 +132,12 @@ EVAL_JUDGE_TIER=full EVAL_VERBOSE=1 bin/test-lane --eval test/evals/<suite>_eval
 
 If multiple suites need to run, run them sequentially (each needs a test lane). If the first suite fails, stop immediately — don't burn API cost on remaining suites.
 
-**4. Check results:**
+**4. 結果を確認:**
 
-- **If any eval fails:** Show the failures, the cost dashboard, and **STOP**. Do not proceed.
-- **If all pass:** Note pass counts and cost. Continue to Step 3.5.
+- **いずれかの eval が失敗した場合:** 失敗内容と cost dashboard を示して **STOP** する。
+- **すべて成功した場合:** pass 件数と cost を記録し、Step 3.5 へ進む。
 
-**5. Save eval output** — include eval results and cost dashboard in the PR body (Step 8).
+**5. eval 出力を保存**し、PR body（Step 8）へ eval 結果と cost dashboard を含める。
 
 **Tier reference (for context — /ship always uses `full`):**
 | Tier | When | Speed (cached) | Cost |
@@ -177,7 +178,7 @@ Save the review output — it goes into the PR body in Step 8.
 
 ---
 
-## Step 3.75: Address Greptile review comments (if PR exists)
+## Step 3.75: Greptile review comments 対応（PR がある場合）
 
 Read `.claude/skills/review/greptile-triage.md` and follow the fetch, filter, classify, and **escalation detection** steps.
 
@@ -216,7 +217,7 @@ For each classified comment:
 
 ---
 
-## Step 4: Version bump (auto-decide)
+## Step 4: Version bump（自動判定）
 
 1. Read the current `VERSION` file (4-digit format: `MAJOR.MINOR.PATCH.MICRO`)
 
@@ -235,7 +236,7 @@ For each classified comment:
 
 ---
 
-## Step 5: CHANGELOG (auto-generate)
+## Step 5: CHANGELOG（自動生成）
 
 1. Read `CHANGELOG.md` header to know the format.
 
@@ -257,7 +258,7 @@ For each classified comment:
 
 ---
 
-## Step 5.5: TODOS.md (auto-update)
+## Step 5.5: TODOS.md（自動更新）
 
 Cross-reference the project's TODOS.md against the changes being shipped. Mark completed items automatically; prompt only if the file is missing or disorganized.
 
@@ -312,7 +313,7 @@ Save this summary — it goes into the PR body in Step 8.
 
 ---
 
-## Step 6: Commit (bisectable chunks)
+## Step 6: Commit（bisectable chunks）
 
 **Goal:** Create small, logical commits that work well with `git bisect` and help LLMs understand what changed.
 
@@ -360,7 +361,7 @@ git push -u origin <branch-name>
 
 ---
 
-## Step 8: Create PR
+## Step 8: PR を作成
 
 Create a pull request using `gh`:
 
@@ -399,7 +400,7 @@ EOF
 
 ---
 
-## Important Rules
+## 重要ルール
 
 - **Never skip tests.** If tests fail, stop.
 - **Never skip the pre-landing review.** If checklist.md is unreadable, stop.


### PR DESCRIPTION
## Issue
- Closes #5

## 変更概要
- 対象の skill template (`*.tmpl`) 10ファイルの user-facing 文言を日本語化
- placeholder / 識別子 / コマンド literal を維持
- generated `SKILL.md` は未編集（#9で再生成前提）

## 対象ファイル
- `SKILL.md.tmpl`
- `browse/SKILL.md.tmpl`
- `qa/SKILL.md.tmpl`
- `setup-browser-cookies/SKILL.md.tmpl`
- `ship/SKILL.md.tmpl`
- `review/SKILL.md.tmpl`
- `plan-ceo-review/SKILL.md.tmpl`
- `plan-eng-review/SKILL.md.tmpl`
- `retro/SKILL.md.tmpl`
- `gstack-upgrade/SKILL.md.tmpl`

## 検証
- `git diff --check`
- placeholder 存在確認（`{{UPDATE_CHECK}}`, `{{BROWSE_SETUP}}`, `{{COMMAND_REFERENCE}}`, `{{SNAPSHOT_FLAGS}}`）

## 制約順守
- `*.tmpl` のみ編集
- runtime code / tests / generated docs は未変更
